### PR TITLE
Update OFI/OMPI/AWS components and cleanup build

### DIFF
--- a/Dockerfile-ngc-hpc
+++ b/Dockerfile-ngc-hpc
@@ -14,12 +14,27 @@ RUN mkdir -p ${SCRIPT_DIR}
 # Should we just use /container as the install dir and put
 # everything (ie, ucx/ofi/ompi/mpich) under /container/{bin|lib}
 # to clean up these arguments?
-ARG WITH_MPI
+# Put all HPC related tools we build under /container/hpc so we can
+# have a shared include, lib, bin, etc to simplify our paths and build steps.
+ARG HPC_DIR=/container/hpc
+RUN mkdir -p ${HPC_DIR}/bin && \
+    mkdir -p ${HPC_DIR}/lib && \
+    mkdir -p ${HPC_DIR}/include && \
+    mkdir -p ${HPC_DIR}/share && \
+    ln -s ${HPC_DIR}/lib ${HPC_DIR}/lib64
+ENV LD_LIBRARY_PATH=$HPC_DIR/lib:$LD_LIBRARY_PATH
+ENV PATH=$HPC_DIR/bin:$PATH
+
+# Install Cray CXI headers/lib
+COPY dockerfile_scripts/cray-libs.sh ${SCRIPT_DIR}
 ARG WITH_OFI
-ARG MPI_TYPE
+RUN if [ "$WITH_OFI" = "1" ]; then \
+    ${SCRIPT_DIR}/cray-libs.sh ; \
+    fi
+
 # Install all HPC related tools under /container (e.g., mpi, ofi, etc).
-ARG OMPI_INSTALL_DIR=/container/ompi
-ARG OFI_INSTALL_DIR=/container/ofi
+ARG WITH_MPI
+ARG MPI_TYPE
 ARG OMPI_WITH_CUDA=1
 COPY dockerfile_scripts/ompi.sh ${SCRIPT_DIR}
 RUN if [ "$WITH_MPI" = "1" ]; then \
@@ -27,21 +42,14 @@ RUN if [ "$WITH_MPI" = "1" ]; then \
 		 "$WITH_OFI" "$OMPI_WITH_CUDA"; \
     fi
 
-# Add our OMPI/OFI bin/lib dirs to the container paths. 
-ENV LD_LIBRARY_PATH=${WITH_MPI:+$OMPI_INSTALL_DIR/lib:$OFI_INSTALL_DIR/lib:}$LD_LIBRARY_PATH
-ENV PATH=${WITH_MPI:+$OMPI_INSTALL_DIR/bin:$OFI_INSTALL_DIR/bin:}$PATH
-
 # Enable running OMPI as root. Note that we only need this if we use OMPI. 
 ENV OMPI_ALLOW_RUN_AS_ROOT ${WITH_MPI:+1}
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM ${WITH_MPI:+1}
 # Need to override this so we don't try using the OMPI built into the
 # base container, which is not built correctly for libfabric
-ENV OPAL_PREFIX=${WITH_MPI:+$OMPI_INSTALL_DIR}
+ENV OPAL_PREFIX=${WITH_MPI:+$HPC_DIR}
 
-ARG AWS_PLUGIN_INSTALL_DIR=/container/aws
 ARG WITH_AWS_TRACE
-ARG INTERNAL_AWS_DS
-ARG INTERNAL_AWS_PATH
 COPY dockerfile_scripts/build_aws.sh ${SCRIPT_DIR}
 RUN if [ "$WITH_OFI" = "1" ]; then \
     ${SCRIPT_DIR}/build_aws.sh "$WITH_OFI" "$WITH_AWS_TRACE"; \
@@ -54,14 +62,6 @@ COPY dockerfile_scripts/build_horovod.sh ${SCRIPT_DIR}
 RUN if [ "$WITH_MPI" = "1" ] ; then \
     ${SCRIPT_DIR}/build_horovod.sh "$WITH_PT" "$WITH_TF"; \
     fi
-
-# See if we were given a non-empty path to a tarball for the SS11
-# libs, and if so, put them into the container and fix up our path
-# so that they can be used rather than the user bind-mounting them at runtime.
-RUN if [ ! -z "$HPC_LIBS_TARBALL" -a "$HPC_LIBS_TARBALL" != "" ]; then \
-    ${SCRIPT_DIR}/install_hpc_libs.sh ; \
-    fi
-ENV LD_LIBRARY_PATH=${HPC_LIBS_TARBALL:+/container/ss11-libs:}$LD_LIBRARY_PATH
 
 # Set an entrypoint that can scrape up the host libfabric.so and then
 # run the user command. This is intended to enable performant execution

--- a/Dockerfile-pytorch-ngc
+++ b/Dockerfile-pytorch-ngc
@@ -20,6 +20,26 @@ RUN python -m pip install  \
     -r ${SCRIPT_DIR}/additional-requirements-torch.txt \
     -r ${SCRIPT_DIR}/additional-requirements.txt
 
+# Put all HPC related tools we build under /container/hpc so we can
+# have a shared include, lib, bin, etc to simplify our paths and build steps.
+ARG HPC_DIR=/container/hpc
+RUN mkdir -p ${HPC_DIR}
+
+# Setup some default env variables. This is for the end user as well
+# as tools we will build since we put include files under HPC_DIR.
+COPY dockerfile_scripts/setup_sh_env.sh ${SCRIPT_DIR}
+RUN ${SCRIPT_DIR}/setup_sh_env.sh
+
+ARG WITH_NCCL
+# If we override NCCL we need to set these env vars for Horovod so that
+# it links against the right one later on when we build it.
+ENV HOROVOD_NCCL_HOME=${WITH_NCCL:+$HPC_DIR}
+ENV HOROVOD_NCCL_LINK=${WITH_NCCL:+SHARED}
+COPY dockerfile_scripts/build_nccl.sh ${SCRIPT_DIR}
+RUN if [ -n "${WITH_NCCL}" ]; then ${SCRIPT_DIR}/build_nccl.sh; fi
+ENV NCCL_LIB_DIR=${HOROVOD_NCCL_HOME}/lib
+ENV LD_LIBRARY_PATH=${WITH_NCCL:+$NCCL_LIB_DIR:}$LD_LIBRARY_PATH
+
 ENV DEEPSPEED_PIP="deepspeed==0.13.0"
 COPY dockerfile_scripts/install_deepspeed.sh ${SCRIPT_DIR}
 RUN ${SCRIPT_DIR}/install_deepspeed.sh

--- a/Dockerfile-ss
+++ b/Dockerfile-ss
@@ -5,16 +5,17 @@ FROM ${BASE_IMAGE}
 # the container at /container/ss11-libs and add that to the LD_LIBRARY_PATH.
 # This allows users to pull in the host libs now rather than at container rt.
 ARG HPC_LIBS_DIR
+ARG HPC_DIR=/container/hpc
 COPY ${HPC_LIBS_DIR} /tmp/ss11-libs
 RUN ls /tmp
 RUN ARCH_TYPE=`uname -m` && \
-    mkdir -p /container/ss11-libs && \
-    cp -r /tmp/ss11-libs/* /container/ss11-libs && \
-    chmod -R go+rX /container/ss11-libs && \
+    mkdir -p ${HPC_DIR}/lib && \
+    cp -r /tmp/ss11-libs/* ${HPC_DIR}/lib && \
+    chmod -R go+rX ${HPC_DIR}/lib && \
     rm -rf /tmp/ss11-libs && \
     ln -s /usr/lib/${ARCH_TYPE}-linux-gnu/libjson-c.so.5 \
        /usr/lib/${ARCH_TYPE}-linux-gnu/libjson-c.so.3
 
-ENV LD_LIBRARY_PATH=/container/ss11-libs:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=${HPC_LIB}/lib:$LD_LIBRARY_PATH
 
 RUN rm -rf /tmp/*

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ HOROVOD_GPU_OPERATIONS := NCCL
 # at runtime.
 WITH_MPI ?= 1
 WITH_OFI ?= 1
-WITH_SS11 ?= 1
+WITH_SS11 ?= 0
 CRAY_LIBFABRIC_DIR ?= "/opt/cray/libfabric/1.15.2.0"
 CRAY_LIBCXI_DIR ?= "/usr"
 

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ endif
 
 ifeq "$(WITH_SS11)" "1"
 	ifeq ($(HPC_LIBS_DIR),)
-           LIBFAB_SO=$(shell find $(CRAY_LIBFABRIC_DIR) -name libfabric\*so)
-           LIBCXI_SO=$(shell find $(CRAY_LIBCXI_DIR) -name libcxi\*so)
+           LIBFAB_SO=$(shell find $(CRAY_LIBFABRIC_DIR) -name libfabric\*so.\*)
+           LIBCXI_SO=$(shell find $(CRAY_LIBCXI_DIR) -name libcxi\*so.\*)
            # Make sure we found the libs
            ifneq ($(and $(LIBFAB_SO),$(LIBCXI_SO)),)
               LIBFAB_DIR=$(shell dirname $(LIBFAB_SO))
@@ -134,17 +134,21 @@ build-sif:
 build-pytorch-ngc:
 	docker build -f Dockerfile-pytorch-ngc \
 		--build-arg BASE_IMAGE="$(NGC_PYTORCH_PREFIX):$(NGC_PYTORCH_VERSION)" \
+		--build-arg "$(NCCL_BUILD_ARG)" \
 		-t $(DOCKERHUB_REGISTRY)/$(NGC_PYTORCH_REPO):$(SHORT_GIT_HASH) \
 		.
 	docker build -f Dockerfile-ngc-hpc \
 		--build-arg "$(MPI_BUILD_ARG)" \
 		--build-arg "$(OFI_BUILD_ARG)" \
-		--build-arg "$(NCCL_BUILD_ARG)" \
 		--build-arg "WITH_PT=1" \
 		--build-arg "WITH_TF=0" \
 		--build-arg BASE_IMAGE="$(DOCKERHUB_REGISTRY)/$(NGC_PYTORCH_REPO):$(SHORT_GIT_HASH)" \
 		-t $(DOCKERHUB_REGISTRY)/$(NGC_PYTORCH_HPC_REPO):$(SHORT_GIT_HASH) \
 		.
+	@echo "HPC_LIBS_DIR: $(HPC_LIBS_DIR)"
+	@echo "WITH_SS11: $(WITH_SS11)"
+	@echo "LIBFAB_DIR: $(LIBFAB_DIR)"
+	@echo "LIBCXI_DIR: $(LIBCXI_DIR)"
 ifneq ($(HPC_LIBS_DIR),)
 	@echo "HPC_LIBS_DIR: $(HPC_LIBS_DIR)"
 	docker build -f Dockerfile-ss \

--- a/dockerfile_scripts/build_aws.sh
+++ b/dockerfile_scripts/build_aws.sh
@@ -11,76 +11,48 @@ if [ $# -gt 1 ] ; then
 fi
 OFI=$1
 
-if [ "$OFI" = "1" ]; then
-  apt-get update \
-        && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-                tcsh
+apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+				      --no-install-recommends tcsh
 
-  # Install AWS_OFI_NCCL
-#  AWS_VER=v1.6.0
-#  AWS_VER_NUM=1.6.0
-  AWS_VER=v1.9.2
-  AWS_VER_NUM=1.9.2
-  AWS_NAME=aws-ofi-nccl
-  AWS_FILE="${AWS_NAME}-${AWS_VER_NUM}"
-  # cuda install dir likely dependent on BaseOS (i.e. ubuntu 20.02)
-  # in case this changes in the future
-  cuda_ver_str=`echo $CUDA_VERSION | awk -F "." '{print $1"."$2}'`
-  GDRCOPY_HOME="/usr"
+# Install AWS_OFI_NCCL
+AWS_VER=v1.13.1
+AWS_VER_NUM=1.13.1
+AWS_NAME=aws-ofi-nccl
+AWS_FILE="${AWS_NAME}-${AWS_VER_NUM}"
+cuda_ver_str=`echo $CUDA_VERSION | awk -F "." '{print $1"."$2}'`
+GDRCOPY_HOME="/usr"
 
-  ARCH_TYPE=`uname -m`
-  if [ $ARCH_TYPE == "x86_64" ]; then
-    CUDA_DIR="/usr/local/cuda-$cuda_ver_str/targets/x86_64-linux"
-  elif [ $ARCH_TYPE == "aarch64" ]; then
-    CUDA_DIR="/usr/local/cuda-$cuda_ver_str/targets/sbsa-linux"
-  fi
+# cuda install dir likely dependent on BaseOS (i.e. ubuntu 20.04)
+# in case this changes in the future
+# ARCH_TYPE=`uname -m`
+# if [ $ARCH_TYPE == "x86_64" ]; then
+#     CUDA_DIR="/usr/local/cuda-$cuda_ver_str/targets/x86_64-linux"
+# elif [ $ARCH_TYPE == "aarch64" ]; then
+#     CUDA_DIR="/usr/local/cuda-$cuda_ver_str/targets/sbsa-linux"
+# fi
+# Cuda path, including version. This should be sufficient for the build
+CUDA_DIR=" --with-cuda=/usr/local/cuda-$cuda_ver_str "
 
-  # AWS_CONFIG_OPTIONS="--prefix ${AWS_PLUGIN_INSTALL_DIR} \
-  # 	  --with-libfabric=${OFI_INSTALL_DIR}            \
-  # 	  --with-nccl=${HOROVOD_NCCL_HOME}               \
-  # 	  --with-mpi=${OMPI_INSTALL_DIR}                 \
-  # 	  --with-gdrcopy=${GDRCOPY_HOME}                 \
-  # 	  --with-cuda=${CUDA_DIR} ${WITH_AWS_TRACE}"
-  AWS_CONFIG_OPTIONS="--prefix ${AWS_PLUGIN_INSTALL_DIR} \
-	  --with-libfabric=${OFI_INSTALL_DIR}            \
-	  --with-mpi=${OMPI_INSTALL_DIR}                 \
+AWS_CONFIG_OPTIONS="--prefix ${HPC_DIR} \
+	  --with-libfabric=${HPC_DIR}            \
+	  --with-mpi=${HPC_DIR}                 \
 	  --with-cuda=${CUDA_DIR} ${WITH_AWS_TRACE}"
-  AWS_SRC_DIR=/tmp/aws-ofi-nccl
-  AWS_BASE_URL="https://github.com/aws/aws-ofi-nccl/archive/refs/tags"
-  AWS_URL="${AWS_BASE_URL}/${AWS_VER}.tar.gz"
-  # The INTERNAL_AWS_DS variable must exist in the env
-  ## INTERNAL_AWS_DS="http://set.to.your.server.name"
-  ## INTERNAL_AWS_PATH="/set/to/aws/tarball/path"
-  if [ -z "$INTERNAL_AWS_DS" ]
-  then
-    echo "Using EXTERNAL AWS $AWS_URL" 
-    # aws-ofi-nccl-1.4.0
-    AWS_BASE_URL="https://github.com/aws/aws-ofi-nccl/releases/download"
-    AWS_NAME="${AWS_NAME}-${AWS_VER_NUM}-aws"
-    AWS_URL="${AWS_BASE_URL}/${AWS_VER}-aws/${AWS_NAME}.tar.gz"
-  else
-    AWS_BASE_URL="http://${INTERNAL_AWS_DS}${INTERNAL_AWS_PATH}"
-    AWS_URL="${AWS_BASE_URL}/${AWS_NAME}.tar.gz"
-    echo "Using INTERNAL AWS $AWS_URL" 
-  fi
-  
-  mkdir -p ${AWS_SRC_DIR}                         && \
+AWS_SRC_DIR=/tmp/aws-ofi-nccl
+AWS_BASE_URL="https://github.com/aws/aws-ofi-nccl/archive/refs/tags"
+AWS_URL="${AWS_BASE_URL}/${AWS_VER}.tar.gz"
+AWS_BASE_URL="https://github.com/aws/aws-ofi-nccl/releases/download"
+AWS_NAME="${AWS_NAME}-${AWS_VER_NUM}-aws"
+AWS_URL="${AWS_BASE_URL}/${AWS_VER}-aws/${AWS_NAME}.tar.gz"
+
+mkdir -p ${AWS_SRC_DIR}                           && \
     cd ${AWS_SRC_DIR}                             && \
-    #    wget -O "${AWS_FILE}.tar.gz" ${AWS_URL}       && \
-    #    tar -xzf ${AWS_FILE}.tar.gz                   && \
-    #    cd ${AWS_FILE}                                && \
-    #    wget -O ${AWS_NAME}.tar.gz ${AWS_URL}         && \
-    #tar -xzf ${AWS_NAME}.tar.gz                   && \
-    wget ${AWS_URL} && \
+    wget ${AWS_URL}                               && \
     tar -xzf ${AWS_NAME}.tar.gz --no-same-owner   && \
     cd ${AWS_NAME}                                && \
-#    wget https://github.com/aws/aws-ofi-nccl/archive/refs/tags/${AWS_VER}.tar.gz && \
-#    tar -xzf ${AWS_VER}.tar.gz --no-same-owner   && \
-#    cd aws-ofi-nccl-${AWS_VER_NUM}                                && \
     ./autogen.sh                                  && \
     ./configure ${AWS_CONFIG_OPTIONS}             && \
     make                                          && \
     make install                                  && \
     cd /tmp                                       && \
     rm -rf ${AWS_SRC_DIR}
-fi

--- a/dockerfile_scripts/build_horovod.sh
+++ b/dockerfile_scripts/build_horovod.sh
@@ -2,6 +2,7 @@
 
 # Try and build a version of Horovod that works with c++-17, which is
 # required by the latest PyTorch
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 export CUDA_HOME=/usr/local/cuda-12
 export HOROVOD_WITHOUT_GLOO=1
 export HOROVOD_CUDA_HOME=/usr/local/cuda

--- a/dockerfile_scripts/build_nccl.sh
+++ b/dockerfile_scripts/build_nccl.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 
-set -e
+set -x
 
-#DEBIAN_FRONTEND=noninteractive apt-get install -y libnccl-dev libnccl2 --no-install-recommends
+cuda_ver_str=`echo $CUDA_VERSION | awk -F "." '{print $1"."$2}'`
+CUDA_DIR="/usr/local/cuda-$cuda_ver_str"
+    
+git clone https://github.com/nvidia/nccl.git /tmp/nccl_src
 
-export NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80"
 
-git clone https://github.com/nvidia/nccl.git /tmp/det_nccl
+(cd /tmp/nccl_src && git checkout v2.23.4-1)
 
-(cd /tmp/det_nccl && git checkout v2.19.3-1)
+export NVCC_GENCODE="-gencode=arch=compute_90,code=sm_90"
+#make DEBUG=1 NVCC_GENCODE=${NVCC_GENCODE} CUDA_HOME=${CUDA_DIR} PREFIX=${HOROVOD_NCCL_HOME} -C /tmp/nccl_src -j 4 install
+make CUDA_HOME=${CUDA_DIR} NVCC_GENCODE=${NVCC_GENCODE} PREFIX=${HOROVOD_NCCL_HOME} -C /tmp/nccl_src -j 4 install
 
-make PREFIX=${HOROVOD_NCCL_HOME} -C /tmp/det_nccl -j 4 install
+rm -rf /tmp/nccl_src
+
 

--- a/dockerfile_scripts/cray-libs.sh
+++ b/dockerfile_scripts/cray-libs.sh
@@ -8,7 +8,7 @@ cray_src_dir=/tmp/cray-libs
 mkdir -p $cray_src_dir && \
     cd $cray_src_dir && \
     git clone https://github.com/HewlettPackard/shs-cassini-headers.git && \
-    git clone https://github.com/HewlettPackard/shs-cxi-driver && \
+    git clone https://github.com/HewlettPackard/shs-cxi-driver.git && \
     git clone https://github.com/HewlettPackard/shs-libcxi.git && \
     git clone https://github.com/HewlettPackard/shs-libfabric.git
 

--- a/dockerfile_scripts/cray-libs.sh
+++ b/dockerfile_scripts/cray-libs.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -x
+
+# Install Cray libcxi. This requires grabbing the cassini/cxi headers
+# and installing them into ${HPC_DIR} so we can compile libcxi.
+cray_src_dir=/tmp/cray-libs
+mkdir -p $cray_src_dir && \
+    cd $cray_src_dir && \
+    git clone https://github.com/HewlettPackard/shs-cassini-headers.git && \
+    git clone https://github.com/HewlettPackard/shs-cxi-driver && \
+    git clone https://github.com/HewlettPackard/shs-libcxi.git && \
+    git clone https://github.com/HewlettPackard/shs-libfabric.git
+
+# Install the cassini headers
+cd $cray_src_dir/shs-cassini-headers && \
+    cp -r include ${HPC_DIR} && \
+    cp -r share ${HPC_DIR} && \
+    cp -r share/cassini-headers /usr/share && \
+    cp -r share/cassini-headers ${HPC_DIR}/share && \
+    cd ../
+
+# Install the cxi-driver headers
+cd $cray_src_dir/shs-cxi-driver && \
+    cp -r include ${HPC_DIR} && \
+    cp include/linux/cxi.h ${HPC_DIR}/include && \
+    cd ../
+    
+# Build libcxi. Note that this will install into ${HPC_DIR} by default,
+# which is what we want so that libfabric/ompi/aws can easily find it.
+#cxi_cflags="-Wno-unused-variable -Wno-unused-but-set-variable -g -O0" 
+#cxi_cppflags="-Wno-unused-variable -Wno-unused-but-set-variable -g -O0"
+cxi_cflags="-Wno-unused-variable -Wno-unused-but-set-variable -I${HPC_DIR}/include -I${HPC_DIR}/linux -I${HPC_DIR}/uapi" 
+cxi_cppflags="-Wno-unused-variable -Wno-unused-but-set-variable -I${HPC_DIR}/include -I${HPC_DIR}/linux -I${HPC_DIR}/uapi"
+cd $cray_src_dir/shs-libcxi && \
+    git checkout -b release/shs-12.0 && \
+    ./autogen.sh && \
+    ./configure --prefix=${HPC_DIR} \
+		CFLAGS="${cxi_cflags}" CPPFLAGS="${cxi_cppflags}" && \
+    make && \
+    make install && \
+    cd ../
+
+cuda_opt=""
+if [ -n $CUDA_VERSION ] ; then
+    cuda_ver_str=`echo $CUDA_VERSION | awk -F "." '{print $1"."$2}'`
+    ARCH_TYPE=`uname -m`
+    if [ $ARCH_TYPE == "x86_64" ]; then
+	CUDA_DIR="/usr/local/cuda-$cuda_ver_str/targets/x86_64-linux"
+    elif [ $ARCH_TYPE == "aarch64" ]; then
+	CUDA_DIR="/usr/local/cuda-$cuda_ver_str/targets/sbsa-linux"
+    fi
+#    cuda_opt=" --with-cuda=${CUDA_DIR} "
+    cuda_opt=" --with-cuda=/usr/local/cuda-$cuda_ver_str "
+fi
+
+# Build and install libfabric. Note that this should see the cxi bits
+# and enable cxi support. It should also install into ${HPC_DIR} so that
+# it is easier for ompi/aws to find it.
+cray_ofi_config_opts="--prefix=${HPC_DIR} --with-cassini-headers=${HPC_DIR} --with-cxi-uapi-headers=${HPC_DIR} --enable-cxi=${HPC_DIR} $cuda_opt --enable-cuda-dlopen --enable-gdrcopy-dlopen --disable-sockets --disable-udp --disable-verbs --disable-mrail --disable-rxd --disable-shm --disable-usnic --disable-rstream --disable-efa --disable-psm2 --disable-psm3 --disable-opx"
+#ofi_cflags="-Wno-unused-variable -Wno-unused-but-set-variable -g -O0" 
+#ofi_cppflags="-Wno-unused-variable -Wno-unused-but-set-variable -g -O0"
+ofi_cflags="-Wno-unused-variable -Wno-unused-but-set-variable -I${HPC_DIR}/include -I${HPC_DIR}/linux -I${HPC_DIR}/uapi" 
+ofi_cppflags="-Wno-unused-variable -Wno-unused-but-set-variable -I${HPC_DIR}/include -I${HPC_DIR}/linux -I${HPC_DIR}/uapi"
+cd $cray_src_dir && \
+    git clone https://github.com/ofiwg/libfabric.git && \
+    cd libfabric && \
+    git checkout -b v2.0.x && \
+    ./autogen.sh && \
+    ./configure CFLAGS="${ofi_cflags}" CPPFLAGS="${ofi_cppflags}" \
+		$cray_ofi_config_opts && \
+    make && \
+    make install && \
+    cd ../
+
+#cd $cray_src_dir/shs-libfabric && \
+#    git checkout -b v2.0.x && \
+#    ./autogen.sh && \
+#    ./configure CFLAGS="${ofi_cflags}" CPPFLAGS="${ofi_cppflags}" \
+#		$cray_ofi_config_opts && \
+#    make && \
+#    make install && \
+#    cd ../
+
+# Clean up our git repos used to build cxi/libfabric
+rm -rf $cray_src_dir

--- a/dockerfile_scripts/install_deb_packages.sh
+++ b/dockerfile_scripts/install_deb_packages.sh
@@ -34,6 +34,16 @@ apt-get update \
     libpmi2-0-dev \
     hwloc \
     libhwloc-dev \
+    libjson-c-dev \
+    libnl-3-dev \
+    libnl-*-3-dev \
+    libconfig-dev \
+    libuv1-dev \
+    fuse \
+    libfuse-dev \
+    libyaml-dev \
+    libsensors-dev \
+    gdb \
     unattended-upgrades \
   && unattended-upgrade \
   && rm -rf /var/lib/apt/lists/* \

--- a/dockerfile_scripts/scrape_libs.sh
+++ b/dockerfile_scripts/scrape_libs.sh
@@ -2,8 +2,7 @@
 
 WHOAMI=$(whoami)
 # Only scrape host libs if AWS/NCCL/OFI was built for this image
-if [ -d /container/aws/lib ]
-#if [ -d /container/lib ]
+if [ -d "${HPC_DIR}/lib" ]
 then
    host_dir="/det_libfabric"
    if [ ! -d "$host_dir" ]; then
@@ -51,22 +50,6 @@ then
        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$host_dir/usr/lib64
        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$host_dir/usr/local/lib64
    fi # end if /det_host exists
-   export LD_LIBRARY_PATH=/container/aws/lib:$LD_LIBRARY_PATH
-#   export LD_LIBRARY_PATH=/container/lib:$LD_LIBRARY_PATH
-
-   tmp_nvcache_dir=$(mktemp -d -p /var/tmp ${WHOAMI}-nvcache-XXXXXXXX)
-
-   # The following env variables are only set if they are curretly unset,empty or null
-   # To override one or more of these variales, simply set them prior to the enrtrypoint
-   # of this image
-   export CUDA_CACHE_PATH=${CUDA_CACHE_PATH:=${tmp_nvcache_dir}}
-
-   export TF_FORCE_GPU_ALLOW_GROWTH=${TF_FORCE_GPU_ALLOW_GROWTH:=true}
-
-   # NOTE: Disable memory registration to workaround the current issues
-   #       between libfabric and cuda.  When those issus are resolved,
-   #       simply set the vaiable to 0 before launching the container.
-   export FI_CXI_DISABLE_HOST_REGISTER=${FI_CXI_DISABLE_HOST_REGISTER:=1}
 
    if [ -r /usr/lib/x86_64-linux-gnu/libp11-kit.so.0 ]
    then
@@ -76,51 +59,78 @@ then
    then
       export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libffi.so.7:$LD_PRELOAD
    fi
-# Execute what we were told to execute
 
+   # Settings specific to RCCL
    if [ "$WITH_RCCL" = "1" ]; then
-      #export LD_LIBRARY_PATH=/scratch2/${WHOAMI}/lib/libfabric-1.21.1:/scratch2/${WHOAMI}/lib:/container/aws/lib:$LD_LIBRARY_PATH
-      #export LD_LIBRARY_PATH=/scratch2/${WHOAMI}/lib/libfabric-1.21.1:/scratch2/${WHOAMI}/lib:$LD_LIBRARY_PATH
-
-      export TF_FORCE_GPU_ALLOW_GROWTH=true
-      export CUDA_CACHE_PATH=/tmp/${WHOAMI}.nvcache
-      export FI_CXI_COMPAT=0
-      export NCCL_SOCKET_IFNAME="hsn0"
-      #export FI_CXI_DISABLE_HOST_REGISTER=1
-      export CUDA_VISIBLE_DEVICES="0,1,2,3"
-
-      export FI_CXI_DEFAULT_TX_SIZE=1024
-      export FI_CXI_DISABLE_CQ_HUGETLB=1
-      export FI_CXI_DEFAULT_CQ_SIZE=131072
-      export FI_CXI_DISABLE_HOST_REGISTER=1
-      export FI_CXI_RX_MATCH_MODE=software
-      export FI_CXI_RDZV_PROTO=alt_read
-      export FI_PROVIDER=^ofi_rxm,efa,ofi_rxd
-      export FI_HMEM_CUDA_USE_GDRCOPY=1
-      export FI_CXI_REQ_BUF_SIZE=8338608
-      export FI_LOG_PROV=cxi
-      export FI_LOG_LEVEL=info
-      export FI_LOG_SUBSYS=domain
-      export FI_CXI_TELEMENTRY=pct_no_mst_nacks,pct_mst_hit_on_som,pct_sct_timeouts,pct_spt_timeouts,pct_tct_timeouts
-
-      export CXI_FORK_SAFE=1
-      export FI_EFA_FORK_SAFE=${CXI_FORK_SAFE}
-      # Avoid hang with NCCL/RCCL and libfabric
-      export FI_MR_CACHE_MONITOR=userfaultfd
-
-      export NCCL_DEBUG=TRACE
-      export RCCL_DEBUG=${NCCL_DEBUG}
-
       if [ "$WITH_NFS_WORKAROUND" = "1" ]; then
          export MIOPEN_USER_DB_PATH="/tmp/${WHOAMI}_${SLURM_LOCALID}"
          export MIOPEN_USER_CACHE_PATH="$MIOPEN_USER_DB_PATH/.cache"
          export MIOPEN_CACHE_DIR=${MIOPEN_USER_CACHE_PATH}
-         echo "MIOPEN_USER_DB_PATH: $MIOPEN_USER_DB_PATH, cache dir: $MIOPEN_USER_CACHE_PATH"
          mkdir -p $MIOPEN_USER_DB_PATH
          mkdir -p $MIOPEN_USER_CACHE_PATH/miopen
          export HOME=${MIOPEN_USER_DB_PATH}
 
       fi
-   fi
+   fi # end if [WITH_RCCL = 1]
+fi # end if [ -d $HPC_DIR ]
+
+# Env settings we want for both nccl/rccl
+tmp_nvcache_dir=$(mktemp -d -p /var/tmp ${WHOAMI}-nvcache-XXXXXXXX)
+# The following env variables are only set if they are currently
+# unset, empty or null. To override one or more of these variables,
+# simply set them prior to the enrtrypoint of this image. Note that
+# the user could provide their own wrapper script entrypoint to
+# override these as well.
+export CUDA_CACHE_PATH=${CUDA_CACHE_PATH:=${tmp_nvcache_dir}}
+export TF_FORCE_GPU_ALLOW_GROWTH=${TF_FORCE_GPU_ALLOW_GROWTH:=true}
+# NOTE: Disable memory registration to workaround the current issues
+#       between libfabric and cuda.  When those issus are resolved,
+#       simply set the vaiable to 0 before launching the container.
+export FI_CXI_DISABLE_HOST_REGISTER=${FI_CXI_DISABLE_HOST_REGISTER:=1}
+export FI_MR_CACHE_MONITOR=${FI_MR_CACHE_MONITOR:=userfaultfd}
+export FI_CXI_RDZV_GET_MIN=${FI_CXI_RDZV_GET_MIN:=0}
+export FI_CXI_SAFE_DEVMEM_COPY_THRESHOLD=${FI_CXI_SAFE_DEVMEM_COPY_THRESHOLD:=16777216}
+# Look for cxi devices and use that to build our NCCL list if there
+nics=""
+if [ -n "`ls /dev | grep cxi`" ] ; then
+    nics=`ls /dev| grep cxi | sed s,cxi,hsn,g | tr '\n' ',' | sed -e 's/,$//g'`
+    export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:=${nics}}
 fi
+gpus=""
+if command -v nvidia-smi >/dev/null 2>&1; then
+    gpus=`nvidia-smi -L | awk '{print $2}' | sed -e 's,:,,g' | tr '\n' ',' | sed -e 's/,$//g'`
+    export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:=${gpus}}
+fi
+# Setting this to 0 showed considerably better performance for
+# the nccl all_reduce test                  
+export NCCL_CROSS_NIC=${NCCL_CROSS_NIC:=0}
+export NCCL_NET_GDR_LEVEL=${NCCL_NET_GDR_LEVEL:=PHB}
+export FI_HMEM_CUDA_USE_GDRCOPY=${FI_HMEM_CUDA_USE_GDRCOPY:=1}
+
+# Check if the driver in the container is newer than the one on the host.
+# If this happens there can be bugs, such as incorrect answers due to
+# invalid messages, due to a race condition at container startup. Some
+# ranks may use the driver on the host where others may use what is in
+# the container. Note that if the GPUs are in default mode vs exclusive
+# then this race condition should not happen.
+if command -v nvidia-smi >/dev/null 2>&1; then
+    # Have a cuda driver in the container so check against the host
+    host_driver=`nvidia-smi --query-gpu=driver_version --format=csv | tail -n 1 | awk -F "." '{print $1}'`
+    if [ -n $CUDA_DRIVER_VERSION ] ; then
+	container_driver=`echo $CUDA_DRIVER_VERSION | awk -F "." '{print $1}'`
+	if [ -n $host_driver ] ; then
+	    if [ -n $container_driver ] ; then
+		if [ $container_driver -gt $host_driver ] ; then
+		    # Make sure the cuda forward compatible path is
+		    # prepended in case there is a driver mismatch between the
+		    # host and container
+		    compat_path=/usr/local/cuda/compat/lib.real
+		    export LD_LIBRARY_PATH=$compat_path:$LD_LIBRARY_PATH
+		fi # end if [ $container_driver -gt $host_driver ]
+	    fi # end if [ -n $container_driver ]
+	fi # end if [ -n $host_driver ]
+    fi # end if [ -n $CUDA_DRIVER_VERSION ]
+fi # end if nvidia-smi binary exists
+
+# Execute what we were told to execute
 exec "${@}"

--- a/dockerfile_scripts/setup_sh_env.sh
+++ b/dockerfile_scripts/setup_sh_env.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -x
+
+# This script is used to alter the default env for Bourne shells.
+# This is helpful since we install HPC related tools in HPC_DIR and
+# it would be good to have the ${HPC_DIR}/include be in the default
+# include path for gcc, etc.
+env_file=/etc/hpc-ai-env.sh
+echo "#!/bin/bash" >> $env_file
+
+hpc_cpath="export CPATH=${HPC_DIR}/include:${HPC_DIR}/include/linux:${HPC_DIR}/include/uapi"
+echo $hpc_cpath >> $env_file
+
+hpc_ldpath="export LD_LIBRARY_PATH=${HPC_DIR}/lib:$LD_LIBRARY_PATH"
+echo $hpc_ldpath >> $env_file
+
+# Add the ${HPC_DIR}/lib to where ld searches
+echo "${HPC_DIR}/lib" >> /etc/ld.so.conf.d/hpc-ai-env.conf
+
+chmod 755 $env_file
+
+# Add the command to source the env_file to /etc/bash.bashrc
+echo "test -f $env_file && source $env_file" >> /etc/bash.bashrc
+
+

--- a/dockerfile_scripts/setup_sh_env.sh
+++ b/dockerfile_scripts/setup_sh_env.sh
@@ -9,10 +9,10 @@ set -x
 env_file=/etc/hpc-ai-env.sh
 echo "#!/bin/bash" >> $env_file
 
-hpc_cpath="export CPATH=${HPC_DIR}/include:${HPC_DIR}/include/linux:${HPC_DIR}/include/uapi"
+hpc_cpath="export CPATH=${HPC_DIR}/include:${HPC_DIR}/include/linux:${HPC_DIR}/include/uapi:\$CPATH"
 echo $hpc_cpath >> $env_file
 
-hpc_ldpath="export LD_LIBRARY_PATH=${HPC_DIR}/lib:$LD_LIBRARY_PATH"
+hpc_ldpath="export LD_LIBRARY_PATH=${HPC_DIR}/lib:\$LD_LIBRARY_PATH"
 echo $hpc_ldpath >> $env_file
 
 # Add the ${HPC_DIR}/lib to where ld searches


### PR DESCRIPTION
Description:

This mod updates several of the key components, including:
  - libfabric 1.x -> 2.0
  - OMPI 4.1.x -> 5.x
  - AWS 1.9.2 -> 1.13.1

A key part of this work is to pull in the Cray source for CXI and libfabric and compile them inside the container. By building from source inside the container we can ensure the libraries link against the right version of libraries, to prevent issues with mismatches if we bind-mount in the libraries from the host system. This also makes it easier to run on the host system since no libraries should need to be mounted from the host.

With the addition of the Cray CXI/libfabric, the installation directory for the HPC libs has been changed to be under /container/hpc. This root directory is now used for all HPC related tools compiled and installed into the container (e.g, CXI, OFI, OMPI and AWS).

Also in this mod are several cleanup bits to the build scripts to remove commented out code and simplify things. Further, the scrape_libs entrypoint was modified to provide default settings for important NCCL/OFI variables and to try working around a potential race condition related to mismatches in cuda driver between the host and container.

Finally, a new script was added that sets up some env variables globally inside the container, apart from the entrypoint script, so that the settings help at container build time as well as runtime. These settings are intended to help gcc/ld during container build time to find the right HPC related headers/libraries.