### PR TITLE
Fix OMPI path in NCCL test build example

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The nccl-tests need to be compiled using the MPI/nccl inside the container:
 ```
 $> cd nccl-tests
 $> singularity shell --nv --bind $TMPDIR --bind `pwd` /projects/benchmarking/public/sif/pytorch-ngc-hpc-dev.sif
-Singularity> make MPI=1 MPI_HOME=/container/ompi
+Singularity> make MPI=1 MPI_HOME=/container/hpc
 Singularity> exit
 ```
 


### PR DESCRIPTION
Fix OMPI path in NCCL test build example. Before, OMPI was installed in its own dir under /container so the path was /container/ompi but now the HPC related packages are all installed under the shared root of /container/hpc.