### PR TITLE
Update the NGC base image to 24.11-py3

### DIFF
--- a/Dockerfile-pytorch-ngc
+++ b/Dockerfile-pytorch-ngc
@@ -40,7 +40,7 @@ RUN if [ -n "${WITH_NCCL}" ]; then ${SCRIPT_DIR}/build_nccl.sh; fi
 ENV NCCL_LIB_DIR=${HOROVOD_NCCL_HOME}/lib
 ENV LD_LIBRARY_PATH=${WITH_NCCL:+$NCCL_LIB_DIR:}$LD_LIBRARY_PATH
 
-ENV DEEPSPEED_PIP="deepspeed==0.13.0"
+ENV DEEPSPEED_PIP="deepspeed==0.16.1"
 COPY dockerfile_scripts/install_deepspeed.sh ${SCRIPT_DIR}
 RUN ${SCRIPT_DIR}/install_deepspeed.sh
 

--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,10 @@ endif
 
 NGC_PYTORCH_PREFIX := nvcr.io/nvidia/pytorch
 NGC_TENSORFLOW_PREFIX := nvcr.io/nvidia/tensorflow
-NGC_PYTORCH_VERSION := 24.03-py3
+NGC_PYTORCH_VERSION := 24.11-py3
 NGC_TENSORFLOW_VERSION := 24.03-tf2-py3
-NGC_PYTORCH_REPO := pytorch-ngc-dev
-NGC_PYTORCH_HPC_REPO := pytorch-ngc-hpc-dev
+NGC_PYTORCH_REPO := ngc-$(NGC_PYTORCH_VERSION)-pt
+NGC_PYTORCH_HPC_REPO := ngc-$(NGC_PYTORCH_VERSION)-pt-hpc
 NGC_TF_REPO := tensorflow-ngc-dev
 NGC_TF_HPC_REPO := tensorflow-ngc-hpc-dev
 

--- a/dockerfile_scripts/build_aws.sh
+++ b/dockerfile_scripts/build_aws.sh
@@ -56,3 +56,8 @@ mkdir -p ${AWS_SRC_DIR}                           && \
     make install                                  && \
     cd /tmp                                       && \
     rm -rf ${AWS_SRC_DIR}
+
+# The NGC base image from 24.11 and newer seems to include a build of
+# the AWS plugin. We need to remove it to prevent issues that could
+# occur if that version is loaded instead of the one we built here.
+rm -rf /opt/amazon

--- a/dockerfile_scripts/install_deepspeed.sh
+++ b/dockerfile_scripts/install_deepspeed.sh
@@ -5,10 +5,10 @@ set -e
 apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y pdsh libaio-dev
 
 #Older versions of deepspeed require pinned pydantic version
-python -m pip install pydantic==1.10.11
+python -m pip install pydantic
 
 # Install some dependencies for the LLM test
-pip install accelerate==0.22.0 arrow==1.2.3 datasets==2.14.5 huggingface-hub==0.17.3 packaging==23.1 safetensors==0.3.3 setuptools==65.7.0 tokenizers==0.14.1 transformers==4.34.1 xxhash==3.3.0 evaluate
+pip install accelerate arrow datasets huggingface-hub packaging safetensors setuptools tokenizers transformers xxhash evaluate
 #Precompile deepspeed ops except sparse_attn which has dubious support
 # Skip precompiling since this fails when using the NGC base image.
 # Need to verify that DS can use NCCL correctly for the comms, etc.

--- a/dockerfile_scripts/scrape_libs.sh
+++ b/dockerfile_scripts/scrape_libs.sh
@@ -135,5 +135,15 @@ if command -v nvidia-smi >/dev/null 2>&1; then
     fi # end if [ -n $CUDA_DRIVER_VERSION ]
 fi # end if nvidia-smi binary exists
 
+# The base ngc container started including a build of the AWS OFI plugin.
+# When running on SS11 systems trying to use the OFI plugin built inside
+# this container, our tests could seg fault when trying to init nccl
+# if we do not preload our version of the plugin. Note that our LD_LIBRARY_PATH
+# points to our library first but we still need to preload our lib otherwise
+# we can segfault if the one from the ngc base image exists.
+if [ -r /container/hpc/lib/libnccl-net.so ]; then
+    export LD_PRELOAD=/container/hpc/lib/libnccl-net.so:$LD_PRELOAD
+fi
+
 # Execute what we were told to execute
 exec "${@}"


### PR DESCRIPTION
Description:

This mod updates the base PyTorch NGC image to 24.11-py3. This updates several components, including NCCL and CUDA. There were some issues however caused by the fact that the base NGC image now includes a build of the AWS OFI plugin targeting the EFA provider. When testing this image a program could seg fault when trying to initialize the nccl backend for torch distributed. However, preloading the AWS OFI plugin built into the HPC version of the container (ie, /container/hpc/lib/libnccl-net.so) then the seg fault goes away.

Also updated the image tagging convention to better reflect the base image that was used.

Tested with:

- Torch distributed resnet 50/101
- NCCL all-reduce
- llama-2 13b