### PR TITLE
Add generic build target for user specified NGC base images

### DIFF
--- a/Dockerfile-ngc-hpc
+++ b/Dockerfile-ngc-hpc
@@ -11,9 +11,6 @@ RUN mkdir -p ${SCRIPT_DIR}
 # torch from source and enabling torch distributed with mpi backend.
 #RUN rm -rf /opt/hpcx /usr/local/mpi
 
-# Should we just use /container as the install dir and put
-# everything (ie, ucx/ofi/ompi/mpich) under /container/{bin|lib}
-# to clean up these arguments?
 # Put all HPC related tools we build under /container/hpc so we can
 # have a shared include, lib, bin, etc to simplify our paths and build steps.
 ARG HPC_DIR=/container/hpc
@@ -21,10 +18,29 @@ RUN mkdir -p ${HPC_DIR}/bin && \
     mkdir -p ${HPC_DIR}/lib && \
     mkdir -p ${HPC_DIR}/include && \
     mkdir -p ${HPC_DIR}/share && \
-    ln -s ${HPC_DIR}/lib ${HPC_DIR}/lib64
+    ln -s ${HPC_DIR}/lib ${HPC_DIR}/lib64 && \
+    chmod -R go+rX ${HPC_DIR}
 ENV LD_LIBRARY_PATH=$HPC_DIR/lib:$LD_LIBRARY_PATH
 ENV PATH=$HPC_DIR/bin:$PATH
 
+# Setup some default env variables. This is for the end user as well
+# as tools we will build since we put include files under HPC_DIR.
+COPY dockerfile_scripts/setup_sh_env.sh ${SCRIPT_DIR}
+RUN ${SCRIPT_DIR}/setup_sh_env.sh
+
+ARG WITH_NCCL
+# If we override NCCL we need to set these env vars for Horovod so that
+# it links against the right one later on when we build it.
+ENV HOROVOD_NCCL_HOME=${WITH_NCCL:+$HPC_DIR}
+ENV HOROVOD_NCCL_LINK=${WITH_NCCL:+SHARED}
+COPY dockerfile_scripts/build_nccl.sh ${SCRIPT_DIR}
+RUN if [ -n "${WITH_NCCL}" ]; then ${SCRIPT_DIR}/build_nccl.sh; fi
+ENV NCCL_LIB_DIR=${HOROVOD_NCCL_HOME}/lib
+ENV LD_LIBRARY_PATH=${WITH_NCCL:+$NCCL_LIB_DIR:}$LD_LIBRARY_PATH
+
+# Should we just use /container as the install dir and put
+# everything (ie, ucx/ofi/ompi/mpich) under /container/{bin|lib}
+# to clean up these arguments?
 # Install Cray CXI headers/lib
 COPY dockerfile_scripts/cray-libs.sh ${SCRIPT_DIR}
 ARG WITH_OFI

--- a/Dockerfile-pytorch-ngc
+++ b/Dockerfile-pytorch-ngc
@@ -20,26 +20,6 @@ RUN python -m pip install  \
     -r ${SCRIPT_DIR}/additional-requirements-torch.txt \
     -r ${SCRIPT_DIR}/additional-requirements.txt
 
-# Put all HPC related tools we build under /container/hpc so we can
-# have a shared include, lib, bin, etc to simplify our paths and build steps.
-ARG HPC_DIR=/container/hpc
-RUN mkdir -p ${HPC_DIR}
-
-# Setup some default env variables. This is for the end user as well
-# as tools we will build since we put include files under HPC_DIR.
-COPY dockerfile_scripts/setup_sh_env.sh ${SCRIPT_DIR}
-RUN ${SCRIPT_DIR}/setup_sh_env.sh
-
-ARG WITH_NCCL
-# If we override NCCL we need to set these env vars for Horovod so that
-# it links against the right one later on when we build it.
-ENV HOROVOD_NCCL_HOME=${WITH_NCCL:+$HPC_DIR}
-ENV HOROVOD_NCCL_LINK=${WITH_NCCL:+SHARED}
-COPY dockerfile_scripts/build_nccl.sh ${SCRIPT_DIR}
-RUN if [ -n "${WITH_NCCL}" ]; then ${SCRIPT_DIR}/build_nccl.sh; fi
-ENV NCCL_LIB_DIR=${HOROVOD_NCCL_HOME}/lib
-ENV LD_LIBRARY_PATH=${WITH_NCCL:+$NCCL_LIB_DIR:}$LD_LIBRARY_PATH
-
 ENV DEEPSPEED_PIP="deepspeed==0.16.1"
 COPY dockerfile_scripts/install_deepspeed.sh ${SCRIPT_DIR}
 RUN ${SCRIPT_DIR}/install_deepspeed.sh

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ CRAY_LIBCXI_DIR ?= "/usr"
 
 # If the user doesn't explicitly pass in a value for BUILD_SIF, then
 # default it to 1 if singularity is in the PATH
-BUILD_SIF ?= $(shell singularity -h 2>/dev/null|head -1c|wc -l)
+BUILD_SIF ?= $(shell singularity -h 2>/dev/null|head -1c 2>/dev/null|wc -l)
 
 # If the user specifies USE_CWD_SIF=1 on the command line, singularity
 # will use the current working directory for temp and cache space, this
@@ -100,6 +100,21 @@ ifeq "$(WITH_SS11)" "1"
 endif
 
 
+# Separate out NGC vs ROCM base images only because it could impact which
+# tools we add, such as nccl vs rccl, in the HPC Dockerfile. Note we could
+# likely modify this to work for both and have a separate flag to specify
+# nccl/rccl, etc, to keep things cleaner.
+ifneq ($(USER_NGC_BASE_IMAGE),)
+        $(shell echo "$(USER_NGC_BASE_IMAGE)" > tmp-user.txt)
+        USER_NGC_IMAGE_REPO=$(shell echo "$(USER_NGC_BASE_IMAGE)" | awk 'BEGIN{FS=OFS="/"}{NF--; print}')
+        USER_NGC_IMAGE_NAME=$(shell echo "$(USER_NGC_BASE_IMAGE)" | awk -F "/" '{print $$NF}' | awk -F ":" '{print $$1}')
+        USER_NGC_IMAGE_VER=$(shell echo "$(USER_NGC_BASE_IMAGE)" | awk -F "/" '{print $$NF}' | awk -F ":" '{print $$NF}')
+        USER_NGC_IMAGE_HPC=$(USER_NGC_IMAGE_REPO)/$(USER_NGC_IMAGE_NAME)-hpc:$(USER_NGC_IMAGE_VER)
+        USER_NGC_IMAGE_SS=$(USER_NGC_IMAGE_REPO)/$(USER_NGC_IMAGE_NAME)-hpc-ss:$(USER_NGC_IMAGE_VER)
+        USER_NGC_IMAGE_SIF=$(shell echo "$(USER_NGC_BASE_IMAGE)" | sed s,'/','-',g | sed s,':','-',g)
+endif
+
+
 NGC_PYTORCH_PREFIX := nvcr.io/nvidia/pytorch
 NGC_TENSORFLOW_PREFIX := nvcr.io/nvidia/tensorflow
 NGC_PYTORCH_VERSION := 24.11-py3
@@ -134,10 +149,10 @@ build-sif:
 build-pytorch-ngc:
 	docker build -f Dockerfile-pytorch-ngc \
 		--build-arg BASE_IMAGE="$(NGC_PYTORCH_PREFIX):$(NGC_PYTORCH_VERSION)" \
-		--build-arg "$(NCCL_BUILD_ARG)" \
 		-t $(DOCKERHUB_REGISTRY)/$(NGC_PYTORCH_REPO):$(SHORT_GIT_HASH) \
 		.
 	docker build -f Dockerfile-ngc-hpc \
+		--build-arg "$(NCCL_BUILD_ARG)" \
 		--build-arg "$(MPI_BUILD_ARG)" \
 		--build-arg "$(OFI_BUILD_ARG)" \
 		--build-arg "WITH_PT=1" \
@@ -169,6 +184,49 @@ else
 	    make build-sif TARGET_TAG="$(NGC_PYTORCH_HPC_REPO):$(SHORT_GIT_HASH)" TARGET_NAME="$(NGC_PYTORCH_HPC_REPO)-$(SHORT_GIT_HASH)"
         endif
 endif
+
+
+# Build an HPC container using the base image provided by the user. 
+# This enables us to append the SS11 bits to an otherwise working
+# user image to make it easier for users to deploy their containers on SS11.
+.PHONY: build-user-spec-ngc
+build-user-spec-ngc:
+	@echo "USER_NGC_BASE_IMAGE: $(USER_NGC_BASE_IMAGE)"
+	@echo "USER_NGC_IMAGE_REPO: $(USER_NGC_IMAGE_REPO)"
+	@echo "USER_NGC_IMAGE_NAME: $(USER_NGC_IMAGE_NAME)"
+	@echo "USER_NGC_IMAGE_VER: $(USER_NGC_IMAGE_VER)"
+	@echo "USER_NGC_IMAGE_HPC: $(USER_NGC_IMAGE_HPC)"
+	@echo "USER_NGC_IMAGE_SS: $(USER_NGC_IMAGE_SS)"
+	@echo "USER_NGC_IMAGE_SIF: $(USER_NGC_IMAGE_SIF)"
+	docker build -f Dockerfile-ngc-hpc \
+		--build-arg "$(NCCL_BUILD_ARG)" \
+		--build-arg "$(MPI_BUILD_ARG)" \
+		--build-arg "$(OFI_BUILD_ARG)" \
+		--build-arg "WITH_PT=1" \
+		--build-arg "WITH_TF=0" \
+		--build-arg BASE_IMAGE="$(USER_NGC_BASE_IMAGE)" \
+		-t $(USER_NGC_IMAGE_HPC)\
+		.
+ifneq ($(HPC_LIBS_DIR),)
+	docker build -f Dockerfile-ss \
+		--build-arg BASE_IMAGE=$(USER_NGC_IMAGE_HPC) \
+		--build-arg "HPC_LIBS_DIR=$(HPC_LIBS_DIR)" \
+		-t $(USER_NGC_IMAGE_SS) \
+		.
+        ifneq ($(HPC_TMP_LIBS_DIR),)
+	    rm -rf $(HPC_LIBS_DIR)
+        endif
+        ifeq "$(BUILD_SIF)" "1"
+	    @echo "BUILD_SIF: $(USER_NGC_IMAGE_SS)"
+	    make build-sif TARGET_TAG="$(USER_NGC_IMAGE_SS)" TARGET_NAME="$(USER_NGC_IMAGE_SIF)"
+        endif
+else
+        ifeq "$(BUILD_SIF)" "1"
+	    @echo "BUILD_SIF: $(USER_NGC_IMAGE_HPC)"
+	    make build-sif TARGET_TAG="$(USER_NGC_IMAGE_HPC)" TARGET_NAME="$(USER_NGC_IMAGE_SIF)"
+        endif
+endif
+
 
 .PHONY: build-tensorflow-ngc
 build-tensorflow-ngc:

--- a/README.md
+++ b/README.md
@@ -143,6 +143,28 @@ $> docker save -o pytorch-ngc-hpc-dev-ss-053a634.tar cray/pytorch-ngc-hpc-dev-ss
 $> singularity build pytorch-ngc-hpc-dev-ss-053a634.sif docker-archive:/path/to/docker/tarball/pytorch-ngc-hpc-dev-ss-053a634.tar
 ```
 
+### User Specified Images
+
+Users can specify which base image to use to simply have the required
+SS related libs (ie, CXI, OFI and AWS OFI) added to their
+containers. This should make it easier for users to update images that
+have the desired packages to work well with NCCL over SS. To enable
+this, the user can specify the build target `build-user-spec-ngc` and
+pass the base image name to use with the argument
+USER_NGC_BASE_IMAGE. For example, the following could be used to build
+the HPC version of the base image that will compile in the CXI,
+libfabric and AWS OFI plugin:
+
+```
+make build-user-spec-ngc USER_NGC_BASE_IMAGE=cray/ngc-24.11-py3-pt:5a96988
+```
+
+If successful, this will create the new `-hpc` version of the image:
+
+```
+Successfully tagged localhost/cray/ngc-24.11-py3-pt-hpc:5a96988
+```
+
 ## Examples
 
 The following examples illustrate how to run various AI benchmarks

--- a/dockerfile_scripts/build_aws.sh
+++ b/dockerfile_scripts/build_aws.sh
@@ -56,8 +56,3 @@ mkdir -p ${AWS_SRC_DIR}                           && \
     make install                                  && \
     cd /tmp                                       && \
     rm -rf ${AWS_SRC_DIR}
-
-# The NGC base image from 24.11 and newer seems to include a build of
-# the AWS plugin. We need to remove it to prevent issues that could
-# occur if that version is loaded instead of the one we built here.
-rm -rf /opt/amazon

--- a/dockerfile_scripts/cray-libs.sh
+++ b/dockerfile_scripts/cray-libs.sh
@@ -6,7 +6,9 @@ set -x
 # libfabric and the AWS plugin. We need to remove it to prevent issues
 # that could occur if that version is loaded instead of the libfabric/ofi
 # libraries we build here.
-rm -rf /opt/amazon
+if [ -d "/opt/amazon" ] ; then
+    rm -rf /opt/amazon
+fi
 
 # Install Cray libcxi. This requires grabbing the cassini/cxi headers
 # and installing them into ${HPC_DIR} so we can compile libcxi.

--- a/dockerfile_scripts/cray-libs.sh
+++ b/dockerfile_scripts/cray-libs.sh
@@ -2,6 +2,12 @@
 
 set -x
 
+# The NGC base image from 24.11 and newer seems to include a build of
+# libfabric and the AWS plugin. We need to remove it to prevent issues
+# that could occur if that version is loaded instead of the libfabric/ofi
+# libraries we build here.
+rm -rf /opt/amazon
+
 # Install Cray libcxi. This requires grabbing the cassini/cxi headers
 # and installing them into ${HPC_DIR} so we can compile libcxi.
 cray_src_dir=/tmp/cray-libs


### PR DESCRIPTION
Description:

This mod adds a new build target for users to specify their own NGC base image. It is not necessary that the image comes from NGC -- only that it is an nvidia based image since it uses the HPC Dockerfile to target NCCL.

The mod also has a couple other minor changes, including:

  - silence unnecessary error message from 'head' for 'singularity' check
  - move the `rm -rf /opt/amazon` to start of Cray libs install so that we remove any libfabric headers/libs installed as well before building our own
  - move the HPC related builds/installs out of Dockerfile-pytorch-ngc to the Dockerfile-ngc-hpc

Tested with:

Used new build target to pass the NGC pytorch image built to have it finish building the SS11 bits, ie:

make build-user-spec-ngc USER_NGC_BASE_IMAGE=cray/ngc-24.11-py3-pt:5a96988

which builds successfully and creates:

Successfully tagged localhost/cray/ngc-24.11-py3-pt-hpc:5a96988