### PR TITLE
Install deb pkgs before building nccl

### DIFF
--- a/Dockerfile-ngc-hpc
+++ b/Dockerfile-ngc-hpc
@@ -28,6 +28,11 @@ ENV PATH=$HPC_DIR/bin:$PATH
 COPY dockerfile_scripts/setup_sh_env.sh ${SCRIPT_DIR}
 RUN ${SCRIPT_DIR}/setup_sh_env.sh
 
+# We run this here even though it might be a repeat from the base image
+# to make sure we have the required bits for building NCCL, libcxi, etc.
+COPY dockerfile_scripts/install_deb_packages.sh ${SCRIPT_DIR}
+RUN ${SCRIPT_DIR}/install_deb_packages.sh
+
 ARG WITH_NCCL
 # If we override NCCL we need to set these env vars for Horovod so that
 # it links against the right one later on when we build it.
@@ -37,11 +42,6 @@ COPY dockerfile_scripts/build_nccl.sh ${SCRIPT_DIR}
 RUN if [ -n "${WITH_NCCL}" ]; then ${SCRIPT_DIR}/build_nccl.sh; fi
 ENV NCCL_LIB_DIR=${HOROVOD_NCCL_HOME}/lib
 ENV LD_LIBRARY_PATH=${WITH_NCCL:+$NCCL_LIB_DIR:}$LD_LIBRARY_PATH
-
-# We run this here even though it might be a repeat from the base image
-# to make sure we have the required bits for building libcxi, etc.
-COPY dockerfile_scripts/install_deb_packages.sh ${SCRIPT_DIR}
-RUN ${SCRIPT_DIR}/install_deb_packages.sh
 
 # Should we just use /container as the install dir and put
 # everything (ie, ucx/ofi/ompi/mpich) under /container/{bin|lib}

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ endif
 build-sif:
 	# Make a tmp dir in the cwd using the tmp_file name.
 	mkdir $(TMP_SIF_BASE)
-	docker save -o "$(TARGET_NAME).tar" $(DOCKERHUB_REGISTRY)/$(TARGET_TAG)
+	docker save -o "$(TARGET_NAME).tar" $(TARGET_TAG)
 	env $(SING_DIRS) \
             SINGULARITY_NOHTTPS=true NAMESPACE="" \
             singularity -vvv build $(TARGET_NAME).sif \
@@ -176,12 +176,14 @@ ifneq ($(HPC_LIBS_DIR),)
         endif
         ifeq "$(BUILD_SIF)" "1"
 	    @echo "BUILD_SIF: $(NGC_PYTORCH_HPC_REPO)-ss:$(SHORT_GIT_HASH)"
-	    make build-sif TARGET_TAG="$(NGC_PYTORCH_HPC_REPO)-ss:$(SHORT_GIT_HASH)" TARGET_NAME="$(NGC_PYTORCH_HPC_REPO)-$(SHORT_GIT_HASH)"
+	    make build-sif TARGET_TAG="$(DOCKERHUB_REGISTRY)/$(NGC_PYTORCH_HPC_REPO)-ss:$(SHORT_GIT_HASH)" \
+                          TARGET_NAME="$(NGC_PYTORCH_HPC_REPO)-$(SHORT_GIT_HASH)"
         endif
 else
         ifeq "$(BUILD_SIF)" "1"
 	    @echo "BUILD_SIF: $(NGC_PYTORCH_HPC_REPO):$(SHORT_GIT_HASH)"
-	    make build-sif TARGET_TAG="$(NGC_PYTORCH_HPC_REPO):$(SHORT_GIT_HASH)" TARGET_NAME="$(NGC_PYTORCH_HPC_REPO)-$(SHORT_GIT_HASH)"
+	    make build-sif TARGET_TAG="$(DOCKERHUB_REGISTRY)/$(NGC_PYTORCH_HPC_REPO):$(SHORT_GIT_HASH)" \
+                          TARGET_NAME="$(NGC_PYTORCH_HPC_REPO)-$(SHORT_GIT_HASH)"
         endif
 endif
 
@@ -255,12 +257,14 @@ ifneq ($(HPC_LIBS_DIR),)
 	endif
         ifeq "$(BUILD_SIF)" "1"
 	    @echo "BUILD_SIF: $(NGC_TF_HPC_REPO)-ss:$(SHORT_GIT_HASH)"
-	    make build-sif TARGET_TAG="$(NGC_TF_HPC_REPO)-ss:$(SHORT_GIT_HASH)" TARGET_NAME="$(NGC_TF_HPC_REPO)-$(SHORT_GIT_HASH)"
+	    make build-sif TARGET_TAG="$(DOCKERHUB_REGISTRY)/$(NGC_TF_HPC_REPO)-ss:$(SHORT_GIT_HASH)" \
+                          TARGET_NAME="$(NGC_TF_HPC_REPO)-$(SHORT_GIT_HASH)"
         endif
 else
         ifeq "$(BUILD_SIF)" "1"
 	    @echo "BUILD_SIF: $(NGC_TF_HPC_REPO):$(SHORT_GIT_HASH)"
-	    make build-sif TARGET_TAG="$(NGC_TF_HPC_REPO):$(SHORT_GIT_HASH)" TARGET_NAME="$(NGC_TF_HPC_REPO)-$(SHORT_GIT_HASH)"
+	    make build-sif TARGET_TAG="$(DOCKERHUB_REGISTRY)/$(NGC_TF_HPC_REPO):$(SHORT_GIT_HASH)" \
+                          TARGET_NAME="$(NGC_TF_HPC_REPO)-$(SHORT_GIT_HASH)"
         endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,6 @@ endif
 # likely modify this to work for both and have a separate flag to specify
 # nccl/rccl, etc, to keep things cleaner.
 ifneq ($(USER_NGC_BASE_IMAGE),)
-        $(shell echo "$(USER_NGC_BASE_IMAGE)" > tmp-user.txt)
         USER_NGC_IMAGE_REPO=$(shell echo "$(USER_NGC_BASE_IMAGE)" | awk 'BEGIN{FS=OFS="/"}{NF--; print}')
         USER_NGC_IMAGE_NAME=$(shell echo "$(USER_NGC_BASE_IMAGE)" | awk -F "/" '{print $$NF}' | awk -F ":" '{print $$1}')
         USER_NGC_IMAGE_VER=$(shell echo "$(USER_NGC_BASE_IMAGE)" | awk -F "/" '{print $$NF}' | awk -F ":" '{print $$NF}')


### PR DESCRIPTION
In the case of build-user-spec-ngc, ensure the deb packages needed for building CXI are installed before the need to build NCCL, in case BUILD_NCCL=1 was passed in.

Additionally, since the registry will be passed in by the user for build-user-spec-ngc builds, ensure that TARGET_TAG includes the registry for normal, local builds.