### PR TITLE
Dont error on rm if files dont exist

### DIFF
--- a/dockerfile_scripts/install_deb_packages.sh
+++ b/dockerfile_scripts/install_deb_packages.sh
@@ -47,6 +47,6 @@ apt-get update \
     unattended-upgrades \
   && unattended-upgrade \
   && rm -rf /var/lib/apt/lists/* \
-  && rm /etc/ssh/ssh_host_ecdsa_key \
-  && rm /etc/ssh/ssh_host_ed25519_key \
-  && rm /etc/ssh/ssh_host_rsa_key
+  && rm -f /etc/ssh/ssh_host_ecdsa_key \
+  && rm -f /etc/ssh/ssh_host_ed25519_key \
+  && rm -f /etc/ssh/ssh_host_rsa_key


### PR DESCRIPTION
In the case where install_deb_packages.sh is run twice, don't error out when removing the ssh keys if they dont exist.