### PR TITLE
Fix missing curl package and change default MPI

### DIFF
--- a/Dockerfile-ngc-hpc
+++ b/Dockerfile-ngc-hpc
@@ -84,6 +84,12 @@ RUN if [ "$WITH_MPI" = "1" ] ; then \
     ${SCRIPT_DIR}/build_horovod.sh "$WITH_PT" "$WITH_TF"; \
     fi
 
+# If we built MPI, override any MPI in /usr/local/mpi that might
+# have been installed by NVIDIA targeting IB.
+RUN if [ "$WITH_MPI" = "1" ] ; then \
+    rm -rf /usr/local/mpi && ln -s /container/hpc /usr/local/mpi; \
+fi
+
 # Set an entrypoint that can scrape up the host libfabric.so and then
 # run the user command. This is intended to enable performant execution
 # on non-IB systems that have a proprietary libfabric.

--- a/dockerfile_scripts/install_deb_packages.sh
+++ b/dockerfile_scripts/install_deb_packages.sh
@@ -10,6 +10,7 @@ apt-get update \
     build-essential \
     ca-certificates \
     curl \
+    libcurl4-openssl-dev \
     daemontools \
     debhelper \
     devscripts \


### PR DESCRIPTION
Description:

This mod adds a possibly missing curl package that is needed by libfabric for the curl.h, etc. This package may not exist, depending on the base docker image, so install it to make sure libfabric can use it.

Also, if we install MPI that targets libfabric, replace the OMPI installed in /usr/local/mpi, which could be there from the base image but would likely target IB.