### PR TITLE
Make horovod build not happen if pip does not exist

### DIFF
--- a/dockerfile_scripts/build_horovod.sh
+++ b/dockerfile_scripts/build_horovod.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Make sure we have pip. Some base images, such as for HPL, will not.
+if ! command -v pip &> /dev/null; then
+    echo "Skipping Horovod install because pip not installed"
+    exit 0;
+fi
+
 # Try and build a version of Horovod that works with c++-17, which is
 # required by the latest PyTorch
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
This mod disables the install of horovod if pip does not exist in the base image. This is possible for some base images from NGC that do not include PyTorch, such as the HPC image for running the HPL benchmarks.

Note that this could also be done by not having the build_horovod.sh exist in the Dockerfile-ngc-hpc.