### PR TITLE
Add build-user-spec-rocm, resolves #17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Ignore temporary files
 *.tmp
+
+# Ignore sif files
+*.sif

--- a/Dockerfile-rocm-hpc
+++ b/Dockerfile-rocm-hpc
@@ -11,6 +11,9 @@ RUN mkdir -p ${SCRIPT_DIR}
 # torch from source and enabling torch distributed with mpi backend.
 #RUN rm -rf /opt/hpcx /usr/local/mpi
 RUN apt remove -y openmpi ucx || true
+#Let's remove existing /opt/ompi; and, link to our version.
+RUN rm -rf /opt/ompi
+RUN ln -s /container/hpc /opt/ompi
 
 # Put all HPC related tools we build under /container/hpc so we can
 # have a shared include, lib, bin, etc to simplify our paths and build steps.
@@ -62,9 +65,9 @@ ARG WITH_MPI=1
 ARG WITH_OFI=1
 ARG WITH_MPICH
 ARG UCX_INSTALL_DIR=/container/ucx
-ARG OMPI_INSTALL_DIR=/container/ompi
+ARG OMPI_INSTALL_DIR=/container/hpc
 ARG MPICH_INSTALL_DIR=/container/mpich
-ARG OFI_INSTALL_DIR=/container/ofi
+ARG OFI_INSTALL_DIR=/container/hpc
 ARG OMPI_WITH_CUDA=0
 ARG OMPI_WITH_ROCM=1
 COPY dockerfile_scripts/ompi_rocm.sh ${SCRIPT_DIR}
@@ -154,7 +157,7 @@ RUN pip install -r ${SCRIPT_DIR}/additional-requirements-rocm.txt
 
 ENV HSA_FORCE_FINE_GRAIN_PCIE=1
 
-ARG AWS_PLUGIN_INSTALL_DIR=/container/aws
+ARG AWS_PLUGIN_INSTALL_DIR=/container/hpc
 ARG WITH_AWS_TRACE
 ARG INTERNAL_AWS_DS
 ARG INTERNAL_AWS_PATH


### PR DESCRIPTION
This PR creates the build-user-spec-rocm target.

### Build
```
make build-user-spec-rocm BUILD_SIF=1 USE_CWD_SIF=1 USER_ROCM_BASE_IMAGE=rocm/pytorch:rocm6.3_ubuntu22.04_py3.10_pytorch_release_2.4.0 2>&1 | tee build-rocm-user-pt-24.04-try4.log
```

### Execute
```
env RCCL_DEBUG=INFO srun --mpi=pmix -t 30 -N 2 --ntasks-per-node=1 -p bardpeak apptainer run --rocm --bind /lus ../../rocm-pytorch-rocm6.3_ubuntu22.04_py3.10_pytorch_release_2.4.0.sif /lus/cflus02/karlon/wrapper.sh ./build/all_reduce_perf -b 8 -e 128M -f 2 -g 8
```

### Results
```
no suitable mounts available.
----------------------
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
----------------------
WORLD_SIZE=2
MASTER_ADDR=pinoak0007
Setting PMIX_MCA_gds=hash
no suitable mounts available.
----------------------
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
----------------------
WORLD_SIZE=2
MASTER_ADDR=pinoak0007
Setting PMIX_MCA_gds=hash
# nThread 1 nGpus 8 minBytes 8 maxBytes 134217728 step: 2(factor) warmup iters: 5 iters: 20 agg iters: 1 validation: 1 graph: 0
#
rccl-tests: Version develop:448c4c7
# Using devices
#   Rank  0 Pid 839388 on pinoak0007 device  0 [0000:c1:00.0] AMD Instinct MI250X
#   Rank  1 Pid 839388 on pinoak0007 device  1 [0000:c6:00.0] AMD Instinct MI250X
#   Rank  2 Pid 839388 on pinoak0007 device  2 [0000:c9:00.0] AMD Instinct MI250X
#   Rank  3 Pid 839388 on pinoak0007 device  3 [0000:ce:00.0] AMD Instinct MI250X
#   Rank  4 Pid 839388 on pinoak0007 device  4 [0000:d1:00.0] AMD Instinct MI250X
#   Rank  5 Pid 839388 on pinoak0007 device  5 [0000:d6:00.0] AMD Instinct MI250X
#   Rank  6 Pid 839388 on pinoak0007 device  6 [0000:d9:00.0] AMD Instinct MI250X
#   Rank  7 Pid 839388 on pinoak0007 device  7 [0000:de:00.0] AMD Instinct MI250X
#   Rank  8 Pid 902317 on pinoak0008 device  0 [0000:c1:00.0] AMD Instinct MI250X
#   Rank  9 Pid 902317 on pinoak0008 device  1 [0000:c6:00.0] AMD Instinct MI250X
#   Rank 10 Pid 902317 on pinoak0008 device  2 [0000:c9:00.0] AMD Instinct MI250X
#   Rank 11 Pid 902317 on pinoak0008 device  3 [0000:ce:00.0] AMD Instinct MI250X
#   Rank 12 Pid 902317 on pinoak0008 device  4 [0000:d1:00.0] AMD Instinct MI250X
#   Rank 13 Pid 902317 on pinoak0008 device  5 [0000:d6:00.0] AMD Instinct MI250X
#   Rank 14 Pid 902317 on pinoak0008 device  6 [0000:d9:00.0] AMD Instinct MI250X
#   Rank 15 Pid 902317 on pinoak0008 device  7 [0000:de:00.0] AMD Instinct MI250X
#
#                                                              out-of-place                       in-place          
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
           8             2     float     sum      -1    92.43    0.00    0.00      0    91.15    0.00    0.00      0
          16             4     float     sum      -1    91.58    0.00    0.00      0    86.80    0.00    0.00      0
          32             8     float     sum      -1    83.81    0.00    0.00      0    74.12    0.00    0.00      0
          64            16     float     sum      -1    73.95    0.00    0.00      0    79.33    0.00    0.00      0
         128            32     float     sum      -1    82.75    0.00    0.00      0    83.37    0.00    0.00      0
         256            64     float     sum      -1    81.96    0.00    0.01      0    78.94    0.00    0.01      0
         512           128     float     sum      -1    85.70    0.01    0.01      0    82.26    0.01    0.01      0
        1024           256     float     sum      -1    86.19    0.01    0.02      0    88.37    0.01    0.02      0
        2048           512     float     sum      -1    84.51    0.02    0.05      0    87.18    0.02    0.04      0
        4096          1024     float     sum      -1    136.9    0.03    0.06      0    144.4    0.03    0.05      0
        8192          2048     float     sum      -1    165.0    0.05    0.09      0    158.0    0.05    0.10      0
       16384          4096     float     sum      -1    191.5    0.09    0.16      0    947.8    0.02    0.03      0
       32768          8192     float     sum      -1    371.1    0.09    0.17      0    347.7    0.09    0.18      0
       65536         16384     float     sum      -1    342.0    0.19    0.36      0    340.3    0.19    0.36      0
      131072         32768     float     sum      -1    346.2    0.38    0.71      0    351.1    0.37    0.70      0
      262144         65536     float     sum      -1    346.8    0.76    1.42      0    376.7    0.70    1.30      0
      524288        131072     float     sum      -1    400.2    1.31    2.46      0    305.8    1.71    3.22      0
     1048576        262144     float     sum      -1   1184.3    0.89    1.66      0    400.5    2.62    4.91      0
     2097152        524288     float     sum      -1    546.3    3.84    7.20      0    539.2    3.89    7.29      0
     4194304       1048576     float     sum      -1    872.6    4.81    9.01      0    831.7    5.04    9.46      0
     8388608       2097152     float     sum      -1    958.4    8.75   16.41      0    942.8    8.90   16.68      0
    16777216       4194304     float     sum      -1   1723.4    9.73   18.25      0   1719.6    9.76   18.29      0
    33554432       8388608     float     sum      -1   3320.8   10.10   18.95      0   3360.6    9.98   18.72      0
    67108864      16777216     float     sum      -1   3536.4   18.98   35.58      0   3706.5   18.11   33.95      0
   134217728      33554432     float     sum      -1   6474.9   20.73   38.87      0   6602.0   20.33   38.12      0
# Errors with asterisks indicate errors that have exceeded the maximum threshold.
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 6.09773 
#

karlon@pinoak-login1:/lus/scratch/karlon/git/rccl-tests>
```