### PR TITLE
Strip down ROCm addition, resolves #22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 
 # Ignore sif files
 *.sif
+
+# Ignore tar files
+*.tar
+

--- a/Dockerfile-pytorch-rocm
+++ b/Dockerfile-pytorch-rocm
@@ -3,10 +3,9 @@ FROM ${BASE_IMAGE}
 
 RUN apt remove -y openmpi ucx || true
 #Let's remove existing /opt/ompi; and, link to our version.
-RUN rm -rf /opt/ompi 
-RUN ln -s /container/hpc /opt/ompi
-
-RUN rm /etc/apt/sources.list.d/rocm.list
+RUN rm -rf /opt/ompi                && \
+    ln -s /container/hpc /opt/ompi  && \
+    rm /etc/apt/sources.list.d/rocm.list
 
 # Copy shell scripts as needed so that a simple change to one of those
 # scripts does not cause this image and all derived images from being
@@ -20,10 +19,10 @@ RUN ${SCRIPT_DIR}/install_deb_packages.sh
 RUN pip install --upgrade pip
 
 COPY dockerfile_scripts/additional-requirements-torch.txt ${SCRIPT_DIR}
-COPY dockerfile_scripts/additional-requirements-rocm.txt ${SCRIPT_DIR}
+COPY dockerfile_scripts/additional-requirements.txt ${SCRIPT_DIR}
 RUN python -m pip install  \
     -r ${SCRIPT_DIR}/additional-requirements-torch.txt \
-    -r ${SCRIPT_DIR}/additional-requirements-rocm.txt
+    -r ${SCRIPT_DIR}/additional-requirements.txt
 
 ENV DEEPSPEED_PIP="deepspeed==0.16.1"
 COPY dockerfile_scripts/install_deepspeed.sh ${SCRIPT_DIR}

--- a/Dockerfile-rocm-hpc
+++ b/Dockerfile-rocm-hpc
@@ -47,108 +47,27 @@ RUN if [ "$WITH_OFI" = "1" ]; then \
     ${SCRIPT_DIR}/cray-libs.sh ; \
     fi
 
-ENV PATH="/opt/conda/envs/py_3.8/bin:${PATH}"
-
-ARG CONDA="${PATH}"
-
-ENV PYTHONUNBUFFERED=1 PYTHONFAULTHANDLER=1 PYTHONHASHSEED=0
-
-# Install fixed version of FFI package for Ubuntu 20.04.
-# This is done after above stuff to make sure we get right version.
-COPY dockerfile_scripts/install_package_fixes.sh ${SCRIPT_DIR}
-RUN ${SCRIPT_DIR}/install_package_fixes.sh
-
 RUN apt install rocm-libs 
 
 #USING OFI
 ARG WITH_MPI=1
 ARG WITH_OFI=1
-ARG WITH_MPICH
-ARG UCX_INSTALL_DIR=/container/ucx
-ARG OMPI_INSTALL_DIR=/container/hpc
-ARG MPICH_INSTALL_DIR=/container/mpich
-ARG OFI_INSTALL_DIR=/container/hpc
 ARG OMPI_WITH_CUDA=0
 ARG OMPI_WITH_ROCM=1
 COPY dockerfile_scripts/ompi.sh ${SCRIPT_DIR}
-RUN if [ "$WITH_MPI" = "1" ]; then ${SCRIPT_DIR}/ompi.sh "$UBUNTU_VERSION" "$WITH_OFI" "$OMPI_WITH_ROCM" "$WITH_MPICH"; fi
-
-# Make sure OMPI/UCX show up in the right paths
-ARG VERBS_LIB_DIR=/usr/lib/libibverbs
-ARG UCX_LIB_DIR=${UCX_INSTALL_DIR}/lib:${UCX_INSTALL_DIR}/lib64
-ARG UCX_PATH_DIR=${UCX_INSTALL_DIR}/bin
-ARG OFI_LIB_DIR=${OFI_INSTALL_DIR}/lib:${OFI_INSTALL_DIR}/lib64
-ARG OFI_PATH_DIR=${OFI_INSTALL_DIR}/bin
-ARG OMPI_LIB_DIR=${OMPI_INSTALL_DIR}/lib
-ARG OMPI_PATH_DIR=${OMPI_INSTALL_DIR}/bin
-ARG MPICH_LIB_DIR=${MPICH_INSTALL_DIR}/lib
-ARG MPICH_PATH_DIR=${MPICH_INSTALL_DIR}/bin
-
-# Set up UCX_LIBS and OFI_LIBS
-ENV UCX_LIBS="${VERBS_LIB_DIR}:${UCX_LIB_DIR}:${OMPI_LIB_DIR}:"
-ENV OFI_LIBS="${VERBS_LIB_DIR}:${OFI_LIB_DIR}:${MPICH_LIB_DIR}:"
-
-# If WITH_OFI is true, then set EXTRA_LIBS to OFI libs, else set to empty string
-ENV EXTRA_LIBS="${WITH_OFI:+${OFI_LIBS}}"
-
-# If EXTRA_LIBS is empty, set to UCX libs, else leave as OFI libs
-ENV EXTRA_LIBS="${EXTRA_LIBS:-${UCX_LIBS}}"
+RUN if [ "$WITH_MPI" = "1" ]; then ${SCRIPT_DIR}/ompi.sh "$UBUNTU_VERSION" "$WITH_OFI" "$OMPI_WITH_ROCM"; fi
 
 # But, only add them if WITH_MPI
-ENV LD_LIBRARY_PATH=${WITH_MPI:+$EXTRA_LIBS}$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/container/hpc/lib:$LD_LIBRARY_PATH
 
 #USING OFI
-ENV PATH=${WITH_OFI:+$PATH:${WITH_MPI:+$OFI_PATH_DIR:$MPICH_PATH_DIR}}
-
-#USING UCX
-ENV PATH=${PATH:-$CONDA:${WITH_MPI:+$UCX_PATH_DIR:$OMPI_PATH_DIR}}
+ENV PATH=/container/hpc/bin:$PATH
 
 # Enable running OMPI as root
-ENV OMPI_ALLOW_RUN_AS_ROOT ${WITH_MPI:+1}
-ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM ${WITH_MPI:+1}
+ENV OMPI_ALLOW_RUN_AS_ROOT=${WITH_MPI:+1}
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=${WITH_MPI:+1}
 
-# google-api-python-client -> google-api-core -> googleapis-common-protos -> protobuf
-# Horovod cannot build with protobuf > 3.20.x
-# latest google-api-python-client requires protobuf >= 3.20.1
-
-ARG TENSORFLOW_PIP
-RUN if [ "$TENSORFLOW_PIP" ]; then pip install $TENSORFLOW_PIP; fi
-
-ARG TORCH_TB_PROFILER_PIP
-RUN if [ "$TORCH_TB_PROFILER_PIP" ]; then pip install $TORCH_TB_PROFILER_PIP; fi
-
-ARG TF_PROFILER_PIP
-RUN if [ "$TF_PROFILER_PIP" ]; then python -m pip install $TF_PROFILER_PIP; fi
-
-# Reset these because we set GPU_OPERATIONS later.
-ENV HOROVOD_GPU_BROADCAST=
-ENV HOROVOD_GPU_ALLREDUCE=
-
-ARG HOROVOD_PIP
-ARG HOROVOD_NCCL_HOME=/opt/rocm/rccl
-ARG HOROVOD_WITH_TENSORFLOW=1
-ARG HOROVOD_WITH_PYTORCH=1
-ARG HOROVOD_WITHOUT_MXNET=1
-ARG HOROVOD_GPU_OPERATIONS=NCCL
-ARG HOROVOD_WITHOUT_MPI=0
-ARG HOROVOD_WITH_MPI=1
-ARG HOROVOD_GPU=ROCM
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
-
-ENV HOROVOD_PIP $HOROVOD_PIP
-ENV HOROVOD_WITH_TENSORFLOW $HOROVOD_WITH_TENSORFLOW
-ENV HOROVOD_WITH_PYTORCH $HOROVOD_WITH_PYTORCH
-ENV HOROVOD_WITHOUT_MXNET $HOROVOD_WITHOUT_MXNET
-ENV HOROVOD_GPU_OPERATIONS $HOROVOD_GPU_OPERATIONS
-ENV HOROVOD_WITHOUT_MPI $HOROVOD_WITHOUT_MPI
-ENV HOROVOD_WITH_MPI $HOROVOD_WITH_MPI
-ENV HOROVOD_GPU $HOROVOD_GPU
-ENV HOROVOD_NCCL_HOME $HOROVOD_NCCL_HOME
-ENV NCCL_LIB_DIR=${HOROVOD_NCCL_HOME}/lib
-ENV HOROVOD_NCCL_LINK=${WITH_OFI:+SHARED}
-ENV LD_LIBRARY_PATH=${WITH_OFI:+$NCCL_LIB_DIR:}$LD_LIBRARY_PATH
-
-###RUN if [ "$HOROVOD_PIP" != "0" ]; then pip install "${HOROVOD_PIP}" ; fi
 
 RUN pip uninstall -y tb-nightly tensorboardX
 COPY dockerfile_scripts/additional-requirements-rocm.txt ${SCRIPT_DIR}
@@ -159,40 +78,12 @@ ENV HSA_FORCE_FINE_GRAIN_PCIE=1
 
 ARG AWS_PLUGIN_INSTALL_DIR=/container/hpc
 ARG WITH_AWS_TRACE
-ARG INTERNAL_AWS_DS
-ARG INTERNAL_AWS_PATH
-ARG ROCM_DIR=/opt/rocm
-ENV ROCM_DIR $ROCM_DIR
 COPY dockerfile_scripts/build_aws.sh ${SCRIPT_DIR}
-RUN if [ "$WITH_OFI" = "1" ]; then ${SCRIPT_DIR}/build_aws.sh "$WITH_OFI" "$WITH_AWS_TRACE" "$WITH_MPICH"; fi
-ENV LD_LIBRARY_PATH=${WITH_OFI:+$AWS_PLUGIN_INSTALL_DIR:}$LD_LIBRARY_PATH
+RUN if [ "$WITH_OFI" = "1" ]; then ${SCRIPT_DIR}/build_aws.sh "$WITH_OFI" "$WITH_AWS_TRACE"; fi
 RUN ldconfig
 
-ENV PATH=$OMPI_PATH_DIR:$OFI_INSTALL_DIR:$PATH
-
-ARG WITH_RCCL=1
-ENV WITH_RCCL=$WITH_RCCL
 ARG WITH_NFS_WORKAROUND=1
 ENV WITH_NFS_WORKAROUND=$WITH_NFS_WORKAROUND
-
-ARG DEEPSPEED_PIP
-ENV DEEPSPEED_PIP=$DEEPSPEED_PIP
-ENV DEEPDEEP=1
-
-ARG BASE_IMAGE
-
-###RUN if [ "$HOROVOD_PIP" != "0" ]; then if [ ! `echo "$BASE_IMAGE"|grep  rocm6.0` ] ; then pip install "${HOROVOD_PIP}" ; fi ; fi;
-#### Try installing Horovod
-###ARG WITH_PT
-###ARG WITH_TF
-###COPY dockerfile_scripts/build_horovod.sh ${SCRIPT_DIR}
-###RUN if [ "$WITH_MPI" = "1" ] ; then \
-###    ${SCRIPT_DIR}/build_horovod.sh "$WITH_PT" "$WITH_TF"; \
-###    fi
-
-###RUN if [ -n "$DEEPSPEED_PIP" ]; then DEBIAN_FRONTEND=noninteractive apt-get install -y pdsh libaio-dev&& git clone https://github.com/ROCmSoftwarePlatform/triton.git && cd triton && git checkout triton-mlir && cd python && pip3 install ninja cmake && pip install -e .;fi
-###RUN if [ -n "$DEEPSPEED_PIP" ]; then DEBIAN_FRONTEND=noninteractive apt-get install -y pdsh libaio-dev&& python -m pip install  pydantic==1.10.11 && git clone https://github.com/ROCmSoftwarePlatform/DeepSpeed.git && cd DeepSpeed && python3 setup.py  build && python3 setup.py install && python -m deepspeed.env_report; fi
-###RUN if [ -n "$DEEPSPEED_PIP" ]; then python -m deepspeed.env_report ; fi
 
 #MIOPEN_DEBUG_SAVE_TEMP_DIR is required to prevent 
 # PAD-133

--- a/Dockerfile-rocm-hpc
+++ b/Dockerfile-rocm-hpc
@@ -70,8 +70,8 @@ ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=${WITH_MPI:+1}
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
 
 RUN pip uninstall -y tb-nightly tensorboardX
-COPY dockerfile_scripts/additional-requirements-rocm.txt ${SCRIPT_DIR}
-RUN pip install -r ${SCRIPT_DIR}/additional-requirements-rocm.txt
+COPY dockerfile_scripts/additional-requirements.txt ${SCRIPT_DIR}
+RUN pip install -r ${SCRIPT_DIR}/additional-requirements.txt
 
 
 ENV HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,6 @@ export ROCM63_TORCH_TF_ENVIRONMENT_NAME := $(ROCM_60_PREFIX)$(ROCM63_TORCH_MPI)
 build-pytorch-rocm:
 	docker build -f Dockerfile-pytorch-rocm $(BUILD_OPTS) \
 		--build-arg BASE_IMAGE="rocm/pytorch:rocm6.3_ubuntu22.04_py3.10_pytorch_release_2.4.0" \
-		--build-arg WITH_MPICH=$(WITH_MPICH) \
 		-t $(DOCKERHUB_REGISTRY)/$(ROCM_PYTORCH_REPO):$(SHORT_GIT_HASH) \
 		-t $(DOCKERHUB_REGISTRY)/$(ROCM63_TORCH_TF_ENVIRONMENT_NAME)-$(VERSION) \
 		.

--- a/dockerfile_scripts/build_aws.sh
+++ b/dockerfile_scripts/build_aws.sh
@@ -35,10 +35,11 @@ GDRCOPY_HOME="/usr"
 CUDA_DIR=" --with-cuda=/usr/local/cuda-$cuda_ver_str "
 
 AWS_SRC_DIR=/tmp/aws-ofi-nccl
+ROCM_DIR=/opt/rocm
 mkdir -p ${AWS_SRC_DIR}
 cd ${AWS_SRC_DIR}
 
-if [ ! -d /opt/rocm ]
+if [ ! -d ${ROCM_DIR} ]
 then
     echo "Building AWS for NVidia"
     AWS_CONFIG_OPTIONS="--prefix ${HPC_DIR}  \
@@ -58,9 +59,9 @@ else
     echo "Building AWS for AMD"
     AWS_CONFIG_OPTIONS="--prefix ${HPC_DIR}  \
       --with-libfabric=${HPC_DIR}            \
-      --with-rccl=${HOROVOD_NCCL_HOME}       \
+      --with-rccl=${ROCM_DIR}/rccl           \
       --with-mpi=${HPC_DIR}                  \
-      --with-hip=${ROCM_DIR} ${WITH_AWS_TRACE}"
+      --with-hip=${ROCM_DIR}   ${WITH_AWS_TRACE}"
     git clone https://github.com/ROCmSoftwarePlatform/aws-ofi-rccl
     cd aws-ofi-rccl
     export CC=hipcc


### PR DESCRIPTION
### Description
This mod more completely synchronizes the ROCm container build process with the NGC version. Tested building both `build-pytorch-rocm` and `build-user-spec-rocm` images and running rccl tests on pinoak.

The following diff may help better understand the current differences:

### sdiff    `  Dockerfile-ngc-hpc                       `   and  `      Dockerfile-rocm-hpc`
```
ARG BASE_IMAGE                                                                  ARG BASE_IMAGE
FROM ${BASE_IMAGE}                                                              FROM ${BASE_IMAGE}

ARG SCRIPT_DIR=/tmp/dockerfile_scripts                                          ARG SCRIPT_DIR=/tmp/dockerfile_scripts
RUN mkdir -p ${SCRIPT_DIR}                                                      RUN mkdir -p ${SCRIPT_DIR}

# Remove the ompi/ucx, etc that is in the base image                            # Remove the ompi/ucx, etc that is in the base image
# Seems that the torch installed in the NGC image links against this.           # Seems that the torch installed in the NGC image links against this.
# Wonder if that will cause problems? We can have it use our OMPI but it        # Wonder if that will cause problems? We can have it use our OMPI but it
# also wants libucs, etc, from UCX. The NGC container must be building          # also wants libucs, etc, from UCX. The NGC container must be building
# torch from source and enabling torch distributed with mpi backend.            # torch from source and enabling torch distributed with mpi backend.
#RUN rm -rf /opt/hpcx /usr/local/mpi                                            #RUN rm -rf /opt/hpcx /usr/local/mpi
                                                                              > RUN apt remove -y openmpi ucx || true
                                                                              > #Let's remove existing /opt/ompi; and, link to our version.
                                                                              > RUN rm -rf /opt/ompi
                                                                              > RUN ln -s /container/hpc /opt/ompi

# Put all HPC related tools we build under /container/hpc so we can             # Put all HPC related tools we build under /container/hpc so we can
# have a shared include, lib, bin, etc to simplify our paths and build steps.   # have a shared include, lib, bin, etc to simplify our paths and build steps.
ARG HPC_DIR=/container/hpc                                                      ARG HPC_DIR=/container/hpc
RUN mkdir -p ${HPC_DIR}/bin && \                                                RUN mkdir -p ${HPC_DIR}/bin && \
    mkdir -p ${HPC_DIR}/lib && \                                                    mkdir -p ${HPC_DIR}/lib && \
    mkdir -p ${HPC_DIR}/include && \                                                mkdir -p ${HPC_DIR}/include && \
    mkdir -p ${HPC_DIR}/share && \                                                  mkdir -p ${HPC_DIR}/share && \
    ln -s ${HPC_DIR}/lib ${HPC_DIR}/lib64 && \                                      ln -s ${HPC_DIR}/lib ${HPC_DIR}/lib64 && \
    chmod -R go+rX ${HPC_DIR}                                                       chmod -R go+rX ${HPC_DIR}
ENV LD_LIBRARY_PATH=$HPC_DIR/lib:$LD_LIBRARY_PATH                               ENV LD_LIBRARY_PATH=$HPC_DIR/lib:$LD_LIBRARY_PATH
ENV PATH=$HPC_DIR/bin:$PATH                                                     ENV PATH=$HPC_DIR/bin:$PATH

# Setup some default env variables. This is for the end user as well            # Setup some default env variables. This is for the end user as well
# as tools we will build since we put include files under HPC_DIR.              # as tools we will build since we put include files under HPC_DIR.
COPY dockerfile_scripts/setup_sh_env.sh ${SCRIPT_DIR}                           COPY dockerfile_scripts/setup_sh_env.sh ${SCRIPT_DIR}
RUN ${SCRIPT_DIR}/setup_sh_env.sh                                               RUN ${SCRIPT_DIR}/setup_sh_env.sh

# We run this here even though it might be a repeat from the base image         # We run this here even though it might be a repeat from the base image
# to make sure we have the required bits for building NCCL, libcxi, etc.        # to make sure we have the required bits for building NCCL, libcxi, etc.
COPY dockerfile_scripts/install_deb_packages.sh ${SCRIPT_DIR}                   COPY dockerfile_scripts/install_deb_packages.sh ${SCRIPT_DIR}
RUN ${SCRIPT_DIR}/install_deb_packages.sh                                       RUN ${SCRIPT_DIR}/install_deb_packages.sh

ARG WITH_NCCL                                                                 <
# If we override NCCL we need to set these env vars for Horovod so that       <
# it links against the right one later on when we build it.                   <
ENV HOROVOD_NCCL_HOME=${WITH_NCCL:+$HPC_DIR}                                  <
ENV HOROVOD_NCCL_LINK=${WITH_NCCL:+SHARED}                                    <
COPY dockerfile_scripts/build_nccl.sh ${SCRIPT_DIR}                           <
RUN if [ -n "${WITH_NCCL}" ]; then ${SCRIPT_DIR}/build_nccl.sh; fi            <
ENV NCCL_LIB_DIR=${HOROVOD_NCCL_HOME}/lib                                     <
ENV LD_LIBRARY_PATH=${WITH_NCCL:+$NCCL_LIB_DIR:}$LD_LIBRARY_PATH              <
                                                                              <
# Should we just use /container as the install dir and put                      # Should we just use /container as the install dir and put
# everything (ie, ucx/ofi/ompi/mpich) under /container/{bin|lib}                # everything (ie, ucx/ofi/ompi/mpich) under /container/{bin|lib}
# to clean up these arguments?                                                  # to clean up these arguments?
# Install Cray CXI headers/lib                                                  # Install Cray CXI headers/lib
COPY dockerfile_scripts/cray-libs.sh ${SCRIPT_DIR}                              COPY dockerfile_scripts/cray-libs.sh ${SCRIPT_DIR}
ARG WITH_OFI                                                                    ARG WITH_OFI
RUN if [ "$WITH_OFI" = "1" ]; then \                                            RUN if [ "$WITH_OFI" = "1" ]; then \
    ${SCRIPT_DIR}/cray-libs.sh ; \                                                  ${SCRIPT_DIR}/cray-libs.sh ; \
    fi                                                                              fi

# Install all HPC related tools under /container (e.g., mpi, ofi, etc).       | RUN apt install rocm-libs 
ARG WITH_MPI                                                                  |
ARG MPI_TYPE                                                                  | #USING OFI
ARG OMPI_WITH_CUDA=1                                                          | ARG WITH_MPI=1
                                                                              > ARG WITH_OFI=1
                                                                              > ARG OMPI_WITH_CUDA=0
                                                                              > ARG OMPI_WITH_ROCM=1
COPY dockerfile_scripts/ompi.sh ${SCRIPT_DIR}                                   COPY dockerfile_scripts/ompi.sh ${SCRIPT_DIR}
RUN if [ "$WITH_MPI" = "1" ]; then \                                          | RUN if [ "$WITH_MPI" = "1" ]; then ${SCRIPT_DIR}/ompi.sh "$UBUNTU_VERSION" "$
    ${SCRIPT_DIR}/ompi.sh "$UBUNTU_VERSION" \                                 |
                 "$WITH_OFI" "$OMPI_WITH_CUDA"; \                             | # But, only add them if WITH_MPI
    fi                                                                        | ENV LD_LIBRARY_PATH=/container/hpc/lib:$LD_LIBRARY_PATH
                                                                              >
                                                                              > #USING OFI
                                                                              > ENV PATH=/container/hpc/bin:$PATH
                                                                              >
                                                                              >
                                                                              > # Enable running OMPI as root
                                                                              > ENV OMPI_ALLOW_RUN_AS_ROOT=${WITH_MPI:+1}
                                                                              > ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=${WITH_MPI:+1}
                                                                              >
                                                                              > ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib

# Enable running OMPI as root. Note that we only need this if we use OMPI.    | RUN pip uninstall -y tb-nightly tensorboardX
ENV OMPI_ALLOW_RUN_AS_ROOT ${WITH_MPI:+1}                                     | COPY dockerfile_scripts/additional-requirements-rocm.txt ${SCRIPT_DIR}
ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM ${WITH_MPI:+1}                             | RUN pip install -r ${SCRIPT_DIR}/additional-requirements-rocm.txt
# Need to override this so we don't try using the OMPI built into the         <
# base container, which is not built correctly for libfabric                  <
ENV OPAL_PREFIX=${WITH_MPI:+$HPC_DIR}                                         <

                                                                              >
                                                                              > ENV HSA_FORCE_FINE_GRAIN_PCIE=1
                                                                              >
                                                                              > ARG AWS_PLUGIN_INSTALL_DIR=/container/hpc
ARG WITH_AWS_TRACE                                                              ARG WITH_AWS_TRACE
COPY dockerfile_scripts/build_aws.sh ${SCRIPT_DIR}                              COPY dockerfile_scripts/build_aws.sh ${SCRIPT_DIR}
RUN if [ "$WITH_OFI" = "1" ]; then \                                          | RUN if [ "$WITH_OFI" = "1" ]; then ${SCRIPT_DIR}/build_aws.sh "$WITH_OFI" "$W
    ${SCRIPT_DIR}/build_aws.sh "$WITH_OFI" "$WITH_AWS_TRACE"; \               | RUN ldconfig
    fi                                                                        <

# Try installing Horovod                                                      | ARG WITH_NFS_WORKAROUND=1
ARG WITH_PT                                                                   | ENV WITH_NFS_WORKAROUND=$WITH_NFS_WORKAROUND
ARG WITH_TF                                                                   <
COPY dockerfile_scripts/build_horovod.sh ${SCRIPT_DIR}                        <
RUN if [ "$WITH_MPI" = "1" ] ; then \                                         <
    ${SCRIPT_DIR}/build_horovod.sh "$WITH_PT" "$WITH_TF"; \                   <
    fi                                                                        <

# If we built MPI, override any MPI in /usr/local/mpi that might              | #MIOPEN_DEBUG_SAVE_TEMP_DIR is required to prevent 
# have been installed by NVIDIA targeting IB.                                 | # PAD-133
RUN if [ "$WITH_MPI" = "1" ] ; then \                                         | ENV MIOPEN_DEBUG_SAVE_TEMP_DIR=1
    rm -rf /usr/local/mpi && ln -s /container/hpc /usr/local/mpi; \           <
fi                                                                            <

# Set an entrypoint that can scrape up the host libfabric.so and then           # Set an entrypoint that can scrape up the host libfabric.so and then
# run the user command. This is intended to enable performant execution         # run the user command. This is intended to enable performant execution
# on non-IB systems that have a proprietary libfabric.                          # on non-IB systems that have a proprietary libfabric.
COPY dockerfile_scripts/scrape_libs.sh ${SCRIPT_DIR}                            COPY dockerfile_scripts/scrape_libs.sh ${SCRIPT_DIR}
RUN mkdir -p /container/bin && \                                                RUN mkdir -p /container/bin && \
    cp ${SCRIPT_DIR}/scrape_libs.sh /container/bin                                  cp ${SCRIPT_DIR}/scrape_libs.sh /container/bin
ENTRYPOINT ["/container/bin/scrape_libs.sh"]                                    ENTRYPOINT ["/container/bin/scrape_libs.sh"]
                                                                              >
                                                                              > CMD ["/bin/bash"]
                                                                              > USER root

RUN rm -r /tmp/*                                                                RUN rm -r /tmp/*
```