### PR TITLE
Fix OMPI build for lnx provider and skip Horovod by default

### DIFF
--- a/Dockerfile-ngc-hpc
+++ b/Dockerfile-ngc-hpc
@@ -80,7 +80,7 @@ RUN if [ "$WITH_OFI" = "1" ]; then \
 ARG WITH_PT
 ARG WITH_TF
 COPY dockerfile_scripts/build_horovod.sh ${SCRIPT_DIR}
-RUN if [ "$WITH_MPI" = "1" ] ; then \
+RUN if [ "$WITH_HOROVOD" = "1" ] ; then \
     ${SCRIPT_DIR}/build_horovod.sh "$WITH_PT" "$WITH_TF"; \
     fi
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ BUILD_OPTS ?=
 WITH_MPI ?= 1
 WITH_OFI ?= 1
 WITH_SS11 ?= 0
+WITH_HOROVOD ?= 0
 CRAY_LIBFABRIC_DIR ?= "/opt/cray/libfabric/1.15.2.0"
 CRAY_LIBCXI_DIR ?= "/usr"
 
@@ -166,6 +167,7 @@ build-pytorch-ngc:
 		--build-arg "$(OFI_BUILD_ARG)" \
 		--build-arg "WITH_PT=1" \
 		--build-arg "WITH_TF=0" \
+		--build-arg "WITH_HOROVOD=$(WITH_HOROVOD)" \
 		--build-arg BASE_IMAGE="$(DOCKERHUB_REGISTRY)/$(NGC_PYTORCH_REPO):$(SHORT_GIT_HASH)" \
 		-t $(DOCKERHUB_REGISTRY)/$(NGC_PYTORCH_HPC_REPO):$(SHORT_GIT_HASH) \
 		.

--- a/dockerfile_scripts/cray-libs.sh
+++ b/dockerfile_scripts/cray-libs.sh
@@ -72,7 +72,7 @@ fi
 # Build and install libfabric. Note that this should see the cxi bits
 # and enable cxi support. It should also install into ${HPC_DIR} so that
 # it is easier for ompi/aws to find it.
-cray_ofi_config_opts="--prefix=${HPC_DIR} --with-cassini-headers=${HPC_DIR} --with-cxi-uapi-headers=${HPC_DIR} --enable-cxi=${HPC_DIR} $cuda_rocm_opt --enable-gdrcopy-dlopen --disable-sockets --disable-udp --disable-verbs --disable-mrail --disable-rxd --disable-shm --disable-usnic --disable-rstream --disable-efa --disable-psm2 --disable-psm3 --disable-opx"
+cray_ofi_config_opts="--prefix=${HPC_DIR} --with-cassini-headers=${HPC_DIR} --with-cxi-uapi-headers=${HPC_DIR} --enable-cxi=${HPC_DIR} $cuda_rocm_opt --enable-gdrcopy-dlopen --disable-verbs --disable-efa --enable-lnx --enable-shm"
 #ofi_cflags="-Wno-unused-variable -Wno-unused-but-set-variable -g -O0" 
 #ofi_cppflags="-Wno-unused-variable -Wno-unused-but-set-variable -g -O0"
 ofi_cflags="-Wno-unused-variable -Wno-unused-but-set-variable -I${HPC_DIR}/include -I${HPC_DIR}/linux -I${HPC_DIR}/uapi" 

--- a/dockerfile_scripts/ompi.sh
+++ b/dockerfile_scripts/ompi.sh
@@ -21,13 +21,28 @@ else
     GPU_OPT="--with-rocm"
 fi
 
+# Create patch for OMPI 5.0.7 for lnx support. Remove this once use newer
+# OMPI that no longer requires this!
+echo "--- ./ompi/mca/mtl/ofi/mtl_ofi_component.c.orig 2024-11-15 08:18:09.000000000 -0600
++++ ./ompi/mca/mtl/ofi/mtl_ofi_component.c      2025-01-23 09:31:04.000000000 -0600
+@@ -832,7 +832,8 @@
+          * have a problem here since it uses fi_mr_regattr only within the context of an rcache, and manages the
+          * requested_key field in this way.
+          */
+-         if (!strncasecmp(prov->fabric_attr->prov_name, \"cxi\", 3)) {
++         if ((NULL != strstr(prov->fabric_attr->prov_name, \"cxi\")) ||
++             (NULL != strstr(prov->fabric_attr->prov_name, \"CXI\")) ) {
+              ompi_mtl_ofi.hmem_needs_reg = false;
+          }
+" > ${SCRIPT_DIR}/mtl_ofi_component.patch
+
 OMPI_CONFIG_OPTIONS_VAR="--prefix ${HPC_DIR} --enable-prte-prefix-by-default \
    --enable-shared --with-cma --with-pic --with-libfabric=${HPC_DIR}         \
    --without-ucx --with-pmix=internal ${GPU_OPT}"
 
 # Install OMPI
 OMPI_VER=v5.0
-OMPI_VER_NUM=5.0.6
+OMPI_VER_NUM=5.0.7
 OMPI_CONFIG_OPTIONS=${OMPI_CONFIG_OPTIONS_VAR}
 OMPI_SRC_DIR=/tmp/openmpi-src
 OMPI_BASE_URL="https://download.open-mpi.org/release/open-mpi"
@@ -38,6 +53,7 @@ mkdir -p ${OMPI_SRC_DIR}                        && \
   wget ${OMPI_URL}                              && \
   tar -xzf openmpi-${OMPI_VER_NUM}.tar.gz       && \
   cd openmpi-${OMPI_VER_NUM}                    && \
+  patch ./ompi/mca/mtl/ofi/mtl_ofi_component.c ${SCRIPT_DIR}/mtl_ofi_component.patch && \
   ./configure ${OMPI_CONFIG_OPTIONS}            && \
   make                                          && \
   make install                                  && \

--- a/dockerfile_scripts/scrape_libs.sh
+++ b/dockerfile_scripts/scrape_libs.sh
@@ -110,6 +110,10 @@ export NCCL_CROSS_NIC=${NCCL_CROSS_NIC:=0}
 export NCCL_NET_GDR_LEVEL=${NCCL_NET_GDR_LEVEL:=PHB}
 export FI_HMEM_CUDA_USE_GDRCOPY=${FI_HMEM_CUDA_USE_GDRCOPY:=1}
 
+# This seems required for newer NGC base images to avoid issues related to
+# the OMPI that was installed in the base and replaced with our OMPI.
+export OMPI_MCA_pml=${OMPI_MCA_pml:="^ucx"}
+
 # Check if the driver in the container is newer than the one on the host.
 # If this happens there can be bugs, such as incorrect answers due to
 # invalid messages, due to a race condition at container startup. Some


### PR DESCRIPTION
Description:

This mod makes a small patch to OMPI 5.0.7 to enable the lnx provider. It also changes the NGC Dockerfile to not build Horovod unless the user specifies to include it.


Tested that the image successfully builds. Will also test on hardware once available.