### PR TITLE
Remove unnecessary apt install, resolves #25

### DIFF
--- a/Dockerfile-rocm-hpc
+++ b/Dockerfile-rocm-hpc
@@ -47,8 +47,6 @@ RUN if [ "$WITH_OFI" = "1" ]; then \
     ${SCRIPT_DIR}/cray-libs.sh ; \
     fi
 
-RUN apt install rocm-libs 
-
 #USING OFI
 ARG WITH_MPI=1
 ARG WITH_OFI=1


### PR DESCRIPTION
The `apt install rocm-libs` is not required for rocm-pytorch or rocm-megatron images, and causes a build failure in the rocm-megatron case due to hipblaslt versions.

Tested rccl tests on pinoak after building with `--no-cache` to ensure a clean build.

This resolves #25 