### PR TITLE
Initial draft xCCL tests

### DIFF
--- a/Dockerfile-ngc-hpc
+++ b/Dockerfile-ngc-hpc
@@ -90,6 +90,12 @@ RUN if [ "$WITH_MPI" = "1" ] ; then \
     rm -rf /usr/local/mpi && ln -s /container/hpc /usr/local/mpi; \
 fi
 
+COPY dockerfile_scripts/build_tests.sh ${SCRIPT_DIR}
+COPY tests/* ${SCRIPT_DIR}
+RUN if [ "$WITH_MPI" = "1" ]; then \
+    ${SCRIPT_DIR}/build_tests.sh;  \
+    fi
+
 # Set an entrypoint that can scrape up the host libfabric.so and then
 # run the user command. This is intended to enable performant execution
 # on non-IB systems that have a proprietary libfabric.

--- a/Dockerfile-rocm-hpc
+++ b/Dockerfile-rocm-hpc
@@ -89,6 +89,12 @@ ENV WITH_NFS_WORKAROUND=$WITH_NFS_WORKAROUND
 # PAD-133
 ENV MIOPEN_DEBUG_SAVE_TEMP_DIR=1
 
+COPY dockerfile_scripts/build_tests.sh ${SCRIPT_DIR}
+RUN if [ "$WITH_MPI" = "1" ]; then \
+    ${SCRIPT_DIR}/build_tests.sh;  \
+    fi
+
+
 # Set an entrypoint that can scrape up the host libfabric.so and then
 # run the user command. This is intended to enable performant execution
 # on non-IB systems that have a proprietary libfabric.

--- a/dockerfile_scripts/build_tests.sh
+++ b/dockerfile_scripts/build_tests.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -x
+SCRIPT_DIR=$(dirname "$0")
+TDIR="/tmp/tests"
+mkdir -p ${TDIR}
+cd ${TDIR}
+if [ ! -d /opt/rocm ]
+then
+    INSTALL_DIR="${HPC_DIR}/tests/nccl-tests"
+    mkdir -p ${INSTALL_DIR}
+    if [ -n $CUDA_VERSION ] ; then
+        cuda_ver_str=`echo $CUDA_VERSION | awk -F "." '{print $1"."$2}'`
+        CUDA_DIR="/usr/local/cuda-$cuda_ver_str"
+    fi
+
+    NCCL_VER="v2.15.0"
+    NCCL_REPO="https://github.com/NVIDIA/nccl-tests.git"
+    git clone --depth 1 --branch ${NCCL_VER} ${NCCL_REPO}
+    cd nccl-tests
+    make -j8  MPI=1 MPI_HOME=${HPC_DIR} CUDA_HOME=${CUDA_DIR} NCCL_HOME=${HPC_DIR} BUILDDIR=${INSTALL_DIR}
+    rm ${INSTALL_DIR}/*.o
+    rm -rf ${INSTALL_DIR}/verifiable
+    make -C ${SCRIPT_DIR}
+else
+    INSTALL_DIR="${HPC_DIR}/tests/rccl-tests"
+    mkdir -p ${INSTALL_DIR}
+
+    RCCL_REPO="https://github.com/ROCm/rccl-tests.git"
+    git clone --depth 1 ${RCCL_REPO}
+    cd rccl-tests
+    make -j8  MPI=1 MPI_HOME=${HPC_DIR} BUILDDIR=${INSTALL_DIR}
+    rm ${INSTALL_DIR}/*.o
+    rm -rf ${INSTALL_DIR}/verifiable
+    rm -rf ${INSTALL_DIR}/src
+    rm -rf ${INSTALL_DIR}/hipify
+fi
+cd /tmp
+rm -rf ${TDIR}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,54 @@
+# Makefile for nccl-sanity
+
+HPC_DIR = /container/hpc
+BUILD_DIR ?= $(HPC_DIR)/tests/nccl-tests
+
+# --- Compiler ---
+NVCC = nvcc
+
+# --- Executable Name ---
+TARGET = $(BUILD_DIR)/nccl-sanity
+
+# --- Source Files ---
+SOURCES = nccl-sanity.c
+
+# --- Configurable Paths (Change these or override on command line) ---
+# Default path for MPI include directory (REQUIRED)
+MPI_INCLUDE_DIR ?= /container/hpc/include
+# Default path for MPI library directory (REQUIRED)
+MPI_LIB_DIR     ?= /container/hpc/lib
+
+# --- Compiler and Linker Flags ---
+# Include directories
+INCLUDES = -I$(MPI_INCLUDE_DIR)
+
+# NVCC Flags (e.g., optimization, architecture)
+# Add -gencode flags for specific architectures if needed, e.g.:
+# NVCCFLAGS = -O2 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_80,code=sm_80
+NVCCFLAGS = -O2
+
+# Linker Flags (Library Paths)
+LDFLAGS = -L$(MPI_LIB_DIR)
+
+# Libraries to Link
+LDLIBS = -lmpi -lcudart -lnccl
+
+# --- Build Rules ---
+
+# Default target
+all: $(TARGET)
+
+# Rule to link the executable
+$(TARGET): $(SOURCES)
+	@echo "Compiling and Linking: $(SOURCES)"
+	mkdir -p $(BUILD_DIR)
+	$(NVCC) $(NVCCFLAGS) $(INCLUDES) $(SOURCES) -o $(TARGET) $(LDFLAGS) $(LDLIBS)
+	@echo "Build complete: $(TARGET)"
+
+# Rule to clean generated files
+clean:
+	@echo "Cleaning..."
+	rm -f $(TARGET)
+
+# Phony targets are not files
+.PHONY: all clean

--- a/tests/nccl-sanity.c
+++ b/tests/nccl-sanity.c
@@ -1,0 +1,245 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>       // For uint64_t used in calculation
+#include <mpi.h>          // For MPI Process Management
+#include <cuda_runtime.h> // For CUDA Runtime API (needed for cudaGetDeviceCount)
+#include <nccl.h>         // For NCCL API
+
+// Error checking macros
+typedef enum {
+  testSuccess = 0,
+  testInternalError = 1,
+  testCudaError = 2,
+  testNcclError = 3,
+  testTimeout = 4,
+  testNumResults = 5
+} testResult_t;
+
+#include <unistd.h>
+
+static void getHostName(char* hostname, int maxlen) {
+  gethostname(hostname, maxlen);
+  for (int i=0; i< maxlen; i++) {
+    if (hostname[i] == '.') {
+      hostname[i] = '\0';
+      return;
+    }
+  }
+}
+
+#define CUDACHECK(cmd) do {                         \
+  cudaError_t err = cmd;                            \
+  if( err != cudaSuccess ) {                        \
+    char hostname[1024];                            \
+    getHostName(hostname, 1024);                    \
+    printf("%s: Test CUDA failure %s:%d '%s'\n",    \
+         hostname,                                  \
+        __FILE__,__LINE__,cudaGetErrorString(err)); \
+    return testCudaError;                           \
+  }                                                 \
+} while(0)
+
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,13,0)
+#define NCCLCHECK(cmd) do {                         \
+  ncclResult_t res = cmd;                           \
+  if (res != ncclSuccess) {                         \
+    char hostname[1024];                            \
+    getHostName(hostname, 1024);                    \
+    printf("%s: Test NCCL failure %s:%d "           \
+           "'%s / %s'\n",                           \
+           hostname,__FILE__,__LINE__,              \
+           ncclGetErrorString(res),                 \
+           ncclGetLastError(NULL));                 \
+    return testNcclError;                           \
+  }                                                 \
+} while(0)
+#else
+#define NCCLCHECK(cmd) do {                         \
+  ncclResult_t res = cmd;                           \
+  if (res != ncclSuccess) {                         \
+    char hostname[1024];                            \
+    getHostName(hostname, 1024);                    \
+    printf("%s: Test NCCL failure %s:%d '%s'\n",    \
+         hostname,                                  \
+        __FILE__,__LINE__,ncclGetErrorString(res)); \
+    return testNcclError;                           \
+  }                                                 \
+} while(0)
+#endif
+
+#define MPICHECK(cmd) do {                          \
+    int e = cmd;                                    \
+    if( e != MPI_SUCCESS ) {                        \
+        fprintf(stderr, "Failed: MPI error %s:%d code %d\n", \
+               __FILE__,__LINE__, e);               \
+        MPI_Abort(MPI_COMM_WORLD, 1);               \
+        exit(EXIT_FAILURE);                         \
+    }                                               \
+} while(0)
+
+
+int main(int argc, char* argv[]) {
+
+    int my_total_rank, num_total_ranks;
+    int num_gpus_available = 0; // Will be filled by cudaGetDeviceCount
+
+    // --- MPI Initialization ---
+    MPICHECK(MPI_Init(&argc, &argv));
+    MPICHECK(MPI_Comm_rank(MPI_COMM_WORLD, &my_total_rank));
+    MPICHECK(MPI_Comm_size(MPI_COMM_WORLD, &num_total_ranks));
+
+    // --- Query Number of GPUs (All Ranks) ---
+    CUDACHECK(cudaGetDeviceCount(&num_gpus_available));
+
+    if (my_total_rank == 0) {
+        printf("Detected %d CUDA-capable GPUs.\n", num_gpus_available);
+    }
+
+    // --- Validation Checks ---
+    if (num_gpus_available <= 0) {
+        if (my_total_rank == 0) {
+            fprintf(stderr, "Error: No CUDA-capable GPUs found or CUDA error.\n");
+        }
+        MPI_Finalize();
+        return 1;
+    }
+
+    if (num_total_ranks % num_gpus_available != 0) {
+        if (my_total_rank == 0) {
+            fprintf(stderr, "Error: Number of MPI ranks (%d) must be divisible "
+                            "by the number of available GPUs (%d) for this "
+                            "program's grouping logic.\n",
+                    num_total_ranks, num_gpus_available);
+        }
+        MPI_Finalize();
+        return 1;
+    }
+
+    // --- Calculate Grouping based on Detected GPUs ---
+    int ranks_per_gpu = num_total_ranks / num_gpus_available;
+ 
+    // Which GPU group I belong to (0 to num_gpus_available-1)
+    int my_gpu_index = my_total_rank / ranks_per_gpu;
+
+    // Am I the leader for my GPU group?
+    int is_leader = (my_total_rank % ranks_per_gpu == 0);
+
+    printf("[Rank %d] Total Ranks: %d, Detected GPUs: %d, Ranks/GPU: %d, "
+           "My GPU Index: %d, Is Leader: %s\n",
+           my_total_rank,
+           num_total_ranks,
+           num_gpus_available,
+           ranks_per_gpu,
+           my_gpu_index,
+           is_leader ? "Yes" : "No");
+
+    // --- Create Local MPI Communicator for each GPU group ---
+    MPI_Comm local_comm;
+    MPICHECK(MPI_Comm_split(MPI_COMM_WORLD, my_gpu_index,
+                            my_total_rank, &local_comm));
+    int my_local_rank;
+
+    // My rank within the local group (0 to ranks_per_gpu-1)
+    MPICHECK(MPI_Comm_rank(local_comm, &my_local_rank));
+
+
+    // --- GPU Selection and Stream Creation (All Ranks) ---
+    cudaStream_t stream;
+    // Assign process to its designated GPU. Ensure GPU index is valid.
+    // The modulo operator could handle cases where ranks > GPUs, mapping back
+    // to available GPUs. However, `my_gpu_index` already ensures it's within
+    // [0, num_gpus_available - 1] because of the divisibility check earlier.
+    CUDACHECK(cudaSetDevice(my_gpu_index));
+    CUDACHECK(cudaStreamCreate(&stream));
+
+    // --- NCCL Setup (Leaders Only) ---
+    ncclUniqueId nccl_id;
+    ncclComm_t nccl_comm = NULL; // Initialize to NULL
+
+    // Get NCCL Unique ID (Rank 0 generates, broadcasts to all)
+    if (my_total_rank == 0) {
+        NCCLCHECK(ncclGetUniqueId(&nccl_id));
+        printf("[Rank 0] Generated NCCL Unique ID.\n");
+    }
+    MPICHECK(MPI_Bcast((void *)&nccl_id, sizeof(nccl_id), MPI_BYTE, 0, MPI_COMM_WORLD));
+
+
+    // Initialize NCCL Communicator (Only Leaders Participate)
+    // The communicator size is the number of GPUs (leaders) participating.
+    if (is_leader) {
+        // Leaders use their GPU index as their rank within the NCCL communicator
+        NCCLCHECK(ncclCommInitRank(&nccl_comm, num_gpus_available, nccl_id, my_gpu_index));
+        printf("[Rank %d] (Leader for GPU %d) Initialized NCCL communicator (NCCL Rank %d of %d).\n",
+               my_total_rank, my_gpu_index, my_gpu_index, num_gpus_available);
+    }
+
+    // --- Data Preparation (All Ranks) ---
+    int my_data = my_total_rank; // Each rank contributes its own total rank number
+    int local_sum = 0;           // Variable to hold the sum within the local group (on CPU)
+    int global_sum = -1;         // Variable to hold the final global sum (on CPU)
+
+    // --- Local Aggregation (MPI Reduce within each group) ---
+    MPICHECK(MPI_Reduce(&my_data, &local_sum, 1, MPI_INT, MPI_SUM, 0, local_comm));
+
+    // --- GPU Buffer Allocation & Transfer (Leaders Only) ---
+    int* send_buff_gpu = NULL;
+    int* recv_buff_gpu = NULL;
+    size_t data_size = sizeof(int);
+
+    if (is_leader) {
+        CUDACHECK(cudaMalloc((void**)&send_buff_gpu, data_size));
+        CUDACHECK(cudaMalloc((void**)&recv_buff_gpu, data_size));
+        CUDACHECK(cudaMemcpyAsync(send_buff_gpu, &local_sum, data_size, cudaMemcpyHostToDevice, stream));
+        // printf("[Rank %d] (Leader) Copied local sum %d to GPU buffer.\n", my_total_rank, local_sum);
+    }
+
+    // --- NCCL Collective Operation (Leaders Only) ---
+    if (is_leader) {
+        // printf("[Rank %d] (Leader) Calling ncclAllReduce...\n", my_total_rank);
+        NCCLCHECK(ncclAllReduce((const void*)send_buff_gpu, (void*)recv_buff_gpu,
+                                1,        // Number of elements
+                                ncclInt,  // Data type
+                                ncclSum,  // Operation
+                                nccl_comm, stream));
+
+        CUDACHECK(cudaStreamSynchronize(stream));
+        // printf("[Rank %d] (Leader) Stream synchronized.\n", my_total_rank);
+
+        CUDACHECK(cudaMemcpy(&global_sum, recv_buff_gpu, data_size, cudaMemcpyDeviceToHost));
+        // printf("[Rank %d] (Leader) Copied final global sum %d from GPU.\n", my_total_rank, global_sum);
+    }
+
+    // --- Local Distribution (MPI Broadcast within each group) ---
+    MPICHECK(MPI_Bcast(&global_sum, 1, MPI_INT, 0, local_comm));
+
+    // --- Verification (All Ranks) ---
+    int expected_sum = (num_total_ranks * (num_total_ranks - 1)) / 2;
+
+    printf("[Rank %d] Final Result Check: Received = %d (Expected = %d)\n",
+           my_total_rank, global_sum, expected_sum);
+
+    if (global_sum != expected_sum) {
+        fprintf(stderr, "[Rank %d] Verification FAILED!\n", my_total_rank);
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    } else {
+        // printf("[Rank %d] Verification PASSED!\n", my_total_rank);
+    }
+
+    // --- Cleanup ---
+    // printf("[Rank %d] Cleaning up...\n", my_total_rank);
+    if (is_leader) {
+        CUDACHECK(cudaFree(send_buff_gpu));
+        CUDACHECK(cudaFree(recv_buff_gpu));
+        if (nccl_comm != NULL) {
+             NCCLCHECK(ncclCommDestroy(nccl_comm));
+        }
+    }
+    CUDACHECK(cudaStreamDestroy(stream));
+    MPICHECK(MPI_Comm_free(&local_comm));
+
+    // Finalize MPI
+    MPICHECK(MPI_Finalize());
+    // printf("[Rank %d] Finished.\n", my_total_rank);
+
+    return 0;
+}


### PR DESCRIPTION
This commit adds nccl-tests and rccl-tests to their respective containers, as well as the first of hopefully several sanity/feature tests for the NGC container.  More tests coming in the future.

Running all-reduce from NGC
```
env SLURM_NOFEEDBACK=1 FI_PROVIDER=cxi NCCL_DEBUG=noinfo  \
   srun --exclusive --mpi=pmix_v5 \
        -N 2 --ntasks-per-node=1 -p champollion \
   singularity run --nv --bind `pwd` \
       /cstor/karlon/ngc-25.02-py3-pt-hpc-6dd2036.sif  \
       /container/hpc/tests/nccl-tests/all_reduce_perf  -b 8M -e 2G -f 2 -g 8
```
with results
```
# nThread 1 nGpus 8 minBytes 8388608 maxBytes 1073741824 step: 2(factor) warmup iters: 5 iters: 20 agg iters: 1 validation: 1 graph: 0
#
# Using devices
#  Rank  0 Group  0 Pid  12897 on   g100n052 device  0 [0000:07:00] NVIDIA A100-SXM4-80GB
#  Rank  1 Group  0 Pid  12897 on   g100n052 device  1 [0000:0b:00] NVIDIA A100-SXM4-80GB
#  Rank  2 Group  0 Pid  12897 on   g100n052 device  2 [0000:48:00] NVIDIA A100-SXM4-80GB
#  Rank  3 Group  0 Pid  12897 on   g100n052 device  3 [0000:4c:00] NVIDIA A100-SXM4-80GB
#  Rank  4 Group  0 Pid  12897 on   g100n052 device  4 [0000:88:00] NVIDIA A100-SXM4-80GB
#  Rank  5 Group  0 Pid  12897 on   g100n052 device  5 [0000:8b:00] NVIDIA A100-SXM4-80GB
#  Rank  6 Group  0 Pid  12897 on   g100n052 device  6 [0000:c8:00] NVIDIA A100-SXM4-80GB
#  Rank  7 Group  0 Pid  12897 on   g100n052 device  7 [0000:cb:00] NVIDIA A100-SXM4-80GB
#  Rank  8 Group  0 Pid  12861 on   g100n053 device  0 [0000:07:00] NVIDIA A100-SXM4-80GB
#  Rank  9 Group  0 Pid  12861 on   g100n053 device  1 [0000:0b:00] NVIDIA A100-SXM4-80GB
#  Rank 10 Group  0 Pid  12861 on   g100n053 device  2 [0000:48:00] NVIDIA A100-SXM4-80GB
#  Rank 11 Group  0 Pid  12861 on   g100n053 device  3 [0000:4c:00] NVIDIA A100-SXM4-80GB
#  Rank 12 Group  0 Pid  12861 on   g100n053 device  4 [0000:88:00] NVIDIA A100-SXM4-80GB
#  Rank 13 Group  0 Pid  12861 on   g100n053 device  5 [0000:8b:00] NVIDIA A100-SXM4-80GB
#  Rank 14 Group  0 Pid  12861 on   g100n053 device  6 [0000:c8:00] NVIDIA A100-SXM4-80GB
#  Rank 15 Group  0 Pid  12861 on   g100n053 device  7 [0000:cb:00] NVIDIA A100-SXM4-80GB
#
#                                                              out-of-place                       in-place          
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
     8388608       2097152     float     sum      -1    715.9   11.72   21.97      0    676.6   12.40   23.25      0
    16777216       4194304     float     sum      -1    921.7   18.20   34.13      0    932.8   17.99   33.72      0
    33554432       8388608     float     sum      -1    983.8   34.11   63.95      0   1126.0   29.80   55.87      0
    67108864      16777216     float     sum      -1   2891.2   23.21   43.52      0   2556.7   26.25   49.22      0
   134217728      33554432     float     sum      -1   3112.0   43.13   80.87      0   3052.2   43.97   82.45      0
   268435456      67108864     float     sum      -1   5459.8   49.17   92.19      0   5656.9   47.45   88.97      0
   536870912     134217728     float     sum      -1    10685   50.25   94.21      0    10702   50.17   94.06      0
  1073741824     268435456     float     sum      -1    21142   50.79   95.22      0    21387   50.21   94.14      0
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 65.4837 
```

Running all-reduce on ROCm (grenoble only have one AMD node):
```
env SLURM_NOFEEDBACK=1 FI_PROVIDER=cxi NCCL_DEBUG=noinfo \
   srun --exclusive --mpi=pmix_v5 -N 1 --ntasks-per-node=1 -p darkstar \
   singularity run --rocm --bind `pwd` \
      /cstor/karlon/rocm6.3.4-py3.10-pt-hpc-6dd2036.sif \
      /container/hpc/tests/rccl-tests/all_reduce_perf  -b 8M -e 1G -f 2 -g8
```

with results:
```
# nThread 1 nGpus 8 minBytes 8388608 maxBytes 1073741824 step: 2(factor) warmup iters: 5 iters: 20 agg iters: 1 validation: 1 graph: 0
#
rccl-tests: Version develop:83d38d9
# Using devices
#  Rank  0 Group  0 Pid  37300 on   g100n126 device  0 [0000:05:00] AMD Instinct MI300X
#  Rank  1 Group  0 Pid  37300 on   g100n126 device  1 [0000:33:00] AMD Instinct MI300X
#  Rank  2 Group  0 Pid  37300 on   g100n126 device  2 [0000:53:00] AMD Instinct MI300X
#  Rank  3 Group  0 Pid  37300 on   g100n126 device  3 [0000:65:00] AMD Instinct MI300X
#  Rank  4 Group  0 Pid  37300 on   g100n126 device  4 [0000:85:00] AMD Instinct MI300X
#  Rank  5 Group  0 Pid  37300 on   g100n126 device  5 [0000:ad:00] AMD Instinct MI300X
#  Rank  6 Group  0 Pid  37300 on   g100n126 device  6 [0000:cd:00] AMD Instinct MI300X
#  Rank  7 Group  0 Pid  37300 on   g100n126 device  7 [0000:e7:00] AMD Instinct MI300X
#
#                                                              out-of-place                       in-place          
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
     8388608       2097152     float     sum      -1    91.10   92.08  161.14      0    94.94   88.36  154.63      0
    16777216       4194304     float     sum      -1    154.8  108.36  189.62      0    160.6  104.47  182.82      0
    33554432       8388608     float     sum      -1    244.9  137.00  239.75      0    258.0  130.03  227.56      0
    67108864      16777216     float     sum      -1    430.2  156.01  273.02      0    443.1  151.44  265.02      0
   134217728      33554432     float     sum      -1    802.0  167.34  292.85      0    811.1  165.47  289.57      0
   268435456      67108864     float     sum      -1   1544.4  173.81  304.17      0   1557.9  172.30  301.53      0
   536870912     134217728     float     sum      -1   3036.7  176.79  309.39      0   3050.2  176.01  308.02      0
  1073741824     268435456     float     sum      -1   5999.3  178.98  313.21      0   6002.5  178.88  313.05      0
# Errors with asterisks indicate errors that have exceeded the maximum threshold.
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 257.834 
```

Running nccl-sanity
```
env SLURM_NOFEEDBACK=1 FI_PROVIDER=cxi NCCL_DEBUG=noinfo srun --exclusive --mpi=pmix_v5 -N 2 --ntasks-per-node=8 -p champollion singularity run --nv --bind `pwd` /cstor/karlon/ngc-25.02-py3-pt-hpc-6dd2036.sif  /container/hpc/tests/nccl-tests/nccl-sanity
```

with results
```
--------------------------------------------------------------------------                                                                        
[Rank 9] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 4, Is Leader: No                                                          
[Rank 9] Final Result Check: Received = 120 (Expected = 120)                                                                                      
[Rank 11] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 5, Is Leader: No                                                         
[Rank 11] Final Result Check: Received = 120 (Expected = 120)                                                                                     
[Rank 13] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 6, Is Leader: No                                                         
[Rank 13] Final Result Check: Received = 120 (Expected = 120)                                                                                     
[Rank 15] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 7, Is Leader: No                                                         
[Rank 15] Final Result Check: Received = 120 (Expected = 120)                                                                                     
[Rank 1] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 0, Is Leader: No
[Rank 1] Final Result Check: Received = 120 (Expected = 120)
[Rank 3] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 1, Is Leader: No
[Rank 3] Final Result Check: Received = 120 (Expected = 120)
[Rank 5] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 2, Is Leader: No
[Rank 5] Final Result Check: Received = 120 (Expected = 120)
[Rank 7] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 3, Is Leader: No
[Rank 7] Final Result Check: Received = 120 (Expected = 120)
[Rank 12] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 6, Is Leader: Yes
[Rank 12] (Leader for GPU 6) Initialized NCCL communicator (NCCL Rank 6 of 8).
[Rank 12] Final Result Check: Received = 120 (Expected = 120)
[Rank 10] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 5, Is Leader: Yes
[Rank 10] (Leader for GPU 5) Initialized NCCL communicator (NCCL Rank 5 of 8).
[Rank 10] Final Result Check: Received = 120 (Expected = 120)
[Rank 14] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 7, Is Leader: Yes
[Rank 14] (Leader for GPU 7) Initialized NCCL communicator (NCCL Rank 7 of 8).
[Rank 14] Final Result Check: Received = 120 (Expected = 120)
[Rank 8] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 4, Is Leader: Yes
[Rank 8] (Leader for GPU 4) Initialized NCCL communicator (NCCL Rank 4 of 8).
[Rank 8] Final Result Check: Received = 120 (Expected = 120)
[Rank 2] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 1, Is Leader: Yes
[Rank 2] (Leader for GPU 1) Initialized NCCL communicator (NCCL Rank 1 of 8).
[Rank 2] Final Result Check: Received = 120 (Expected = 120)
Detected 8 CUDA-capable GPUs.
[Rank 0] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 0, Is Leader: Yes
[Rank 0] Generated NCCL Unique ID.
[Rank 0] (Leader for GPU 0) Initialized NCCL communicator (NCCL Rank 0 of 8).
[Rank 0] Final Result Check: Received = 120 (Expected = 120)
[Rank 6] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 3, Is Leader: Yes
[Rank 6] (Leader for GPU 3) Initialized NCCL communicator (NCCL Rank 3 of 8).
[Rank 6] Final Result Check: Received = 120 (Expected = 120)
[Rank 4] Total Ranks: 16, Detected GPUs: 8, Ranks/GPU: 2, My GPU Index: 2, Is Leader: Yes
[Rank 4] (Leader for GPU 2) Initialized NCCL communicator (NCCL Rank 2 of 8).
[Rank 4] Final Result Check: Received = 120 (Expected = 120)
```