### PR TITLE
Add trailing slash to signify directory for COPY

### DIFF
--- a/Dockerfile-ngc-hpc
+++ b/Dockerfile-ngc-hpc
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SCRIPT_DIR=/tmp/dockerfile_scripts
+ARG SCRIPT_DIR=/tmp/dockerfile_scripts/
 RUN mkdir -p ${SCRIPT_DIR}
 
 # Remove the ompi/ucx, etc that is in the base image

--- a/Dockerfile-pytorch-ngc
+++ b/Dockerfile-pytorch-ngc
@@ -8,7 +8,7 @@ RUN chown root:root /usr/lib
 # scripts does not cause this image and all derived images from being
 # completely rebuilt. This can save significant build time, especially for
 # the HPC images.
-ARG SCRIPT_DIR=/tmp/dockerfile_scripts
+ARG SCRIPT_DIR=/tmp/dockerfile_scripts/
 RUN mkdir -p ${SCRIPT_DIR}
 
 COPY dockerfile_scripts/install_deb_packages.sh ${SCRIPT_DIR}

--- a/Dockerfile-pytorch-rocm
+++ b/Dockerfile-pytorch-rocm
@@ -11,7 +11,7 @@ RUN rm -rf /opt/ompi                && \
 # scripts does not cause this image and all derived images from being
 # completely rebuilt. This can save significant build time, especially for
 # the HPC images.
-ARG SCRIPT_DIR=/tmp/dockerfile_scripts
+ARG SCRIPT_DIR=/tmp/dockerfile_scripts/
 RUN mkdir -p ${SCRIPT_DIR}
 
 COPY dockerfile_scripts/install_deb_packages.sh ${SCRIPT_DIR}

--- a/Dockerfile-rocm-hpc
+++ b/Dockerfile-rocm-hpc
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SCRIPT_DIR=/tmp/dockerfile_scripts
+ARG SCRIPT_DIR=/tmp/dockerfile_scripts/
 RUN mkdir -p ${SCRIPT_DIR}
 
 # Remove the ompi/ucx, etc that is in the base image


### PR DESCRIPTION
Some versions of docker/podman require a trailing slash on directory names for a copy command like 
```
COPY tests/* ${SCRIPT_DIR}
```
This PR includes the trailing slash in the definition of `SCRIPT_DIR`

Build is successful

```
$ grep COPY\  build-pytorch-ngc.log                                                     
#8 [ 4/11] COPY dockerfile_scripts/install_deb_packages.sh /tmp/dockerfile_scripts/                                                               
#10 [ 6/11] COPY dockerfile_scripts/additional-requirements-torch.txt /tmp/dockerfile_scripts/                                                    
#11 [ 7/11] COPY dockerfile_scripts/additional-requirements.txt /tmp/dockerfile_scripts/                                                          
#13 [ 9/11] COPY dockerfile_scripts/install_deepspeed.sh /tmp/dockerfile_scripts/                                                                 
#8 [ 4/24] COPY dockerfile_scripts/setup_sh_env.sh /tmp/dockerfile_scripts/
#10 [ 6/24] COPY dockerfile_scripts/install_deb_packages.sh /tmp/dockerfile_scripts/
#12 [ 8/24] COPY dockerfile_scripts/build_nccl.sh /tmp/dockerfile_scripts/
#14 [10/24] COPY dockerfile_scripts/cray-libs.sh /tmp/dockerfile_scripts/ 
#16 [12/24] COPY dockerfile_scripts/ompi.sh /tmp/dockerfile_scripts/
#18 [14/24] COPY dockerfile_scripts/build_aws.sh /tmp/dockerfile_scripts/ 
#20 [16/24] COPY dockerfile_scripts/build_horovod.sh /tmp/dockerfile_scripts/
#23 [19/24] COPY dockerfile_scripts/build_tests.sh /tmp/dockerfile_scripts/
#24 [20/24] COPY tests/* /tmp/dockerfile_scripts/
#26 [22/24] COPY dockerfile_scripts/scrape_libs.sh /tmp/dockerfile_scripts/
```