### PR TITLE
Build libfabric from the main branch 

### DIFF
--- a/dockerfile_scripts/build_aws.sh
+++ b/dockerfile_scripts/build_aws.sh
@@ -54,21 +54,6 @@ then
       --with-mpi=${HPC_DIR}                  \
       --with-cuda=${CUDA_DIR} ${WITH_AWS_TRACE}"
 
-    # FI_MR_DMABUF:
-    # This flag indicates that the memory region to registered is
-    # a DMA-buf backed region. When set, the region is specified through
-    # the dmabuf field of the fi_mr_attr structure. This flag is only
-    # usable for domains opened with FI_HMEM capability support.
-    # This flag is introduced since Libfabric 1.20.
-    #
-    # When this flag was left default with 'yes' it seems to cause
-    # seg-fault on internal A100 sytem (pinoak)
-    ARCH_TYPE=`uname -m`
-    if [ $ARCH_TYPE == "x86_64" ]; then
-        AWS_CONFIG_OPTIONS="$AWS_CONFIG_OPTIONS \
-	    ac_cv_have_decl_FI_MR_DMABUF=no"
-    fi
-
     AWS_BASE_URL="https://github.com/aws/aws-ofi-nccl/archive/refs/tags"
     AWS_URL="${AWS_BASE_URL}/${AWS_VER}.tar.gz"
     AWS_BASE_URL="https://github.com/aws/aws-ofi-nccl/releases/download"

--- a/dockerfile_scripts/cray-libs.sh
+++ b/dockerfile_scripts/cray-libs.sh
@@ -77,16 +77,37 @@ cray_ofi_config_opts="--prefix=${HPC_DIR} --with-cassini-headers=${HPC_DIR} --wi
 ofi_cflags="-Wno-unused-variable -Wno-unused-but-set-variable -I${HPC_DIR}/include -I${HPC_DIR}/linux -I${HPC_DIR}/uapi" 
 ofi_cppflags="-Wno-unused-variable -Wno-unused-but-set-variable -I${HPC_DIR}/include -I${HPC_DIR}/linux -I${HPC_DIR}/uapi"
 
-LIBFABRIC_VERSION=2.1.0
-LIBFABRIC_BASE_URL="https://github.com/ofiwg/libfabric/releases/download"
-LIBFABRIC_NAME="libfabric-${LIBFABRIC_VERSION}"
-LIBFABRIC_URL="${LIBFABRIC_BASE_URL}/v${LIBFABRIC_VERSION}/${LIBFABRIC_NAME}.tar.bz2"
+
+## Building from the Libfabric Releae tar-file
+
+#LIBFABRIC_VERSION=2.1.0
+#LIBFABRIC_BASE_URL="https://github.com/ofiwg/libfabric/releases/download"
+#LIBFABRIC_NAME="libfabric-${LIBFABRIC_VERSION}"
+#LIBFABRIC_URL="${LIBFABRIC_BASE_URL}/v${LIBFABRIC_VERSION}/${LIBFABRIC_NAME}.tar.bz2"
+
+#cd $cray_src_dir                       && \
+#    wget ${LIBFABRIC_URL}              && \
+#    tar -jxf ${LIBFABRIC_NAME}.tar.bz2    \
+#        --no-same-owner                && \
+#    cd ${LIBFABRIC_NAME}               && \
+#    ./autogen.sh                       && \
+#    ./configure CFLAGS="${ofi_cflags}"    \
+#        CPPFLAGS="${ofi_cppflags}"        \
+#	 $cray_ofi_config_opts          && \
+#    make                               && \
+#    make install                       && \
+#    cd ../
+
+
+## Building from the Libfabric main branch
+
+LIBFABRIC_BASE_URL="https://github.com/ofiwg/libfabric.git"
+LIBFABRIC_BRANCH="main"
 
 cd $cray_src_dir                       && \
-    wget ${LIBFABRIC_URL}              && \
-    tar -jxf ${LIBFABRIC_NAME}.tar.bz2    \
-        --no-same-owner                && \
-    cd ${LIBFABRIC_NAME}               && \
+    git clone ${LIBFABRIC_BASE_URL}    && \
+    cd libfabric                       && \
+    git checkout ${LIBFABRIC_BRANCH}   && \
     ./autogen.sh                       && \
     ./configure CFLAGS="${ofi_cflags}"    \
         CPPFLAGS="${ofi_cppflags}"        \


### PR DESCRIPTION
Updated to build the libfabric from the main branch.
This is done so that we can pick up the fix to allow for passing opaque 64-bit data in ctrl_msg (commit 61398ef).

Also updated the aws NCCL OFI build to remove the workaround to set "ac_cv_have_decl_FI_MR_DMABUF=no"
This can be done by setting the environment variable "OFI_NCCL_DISABLE_DMABUF=1" at the run time.

Tested on Pinoak (A100) and Redoak (GH200) system.