### PR TITLE
Remove extraneous log msg

### DIFF
--- a/dockerfile_scripts/scrape_libs.sh
+++ b/dockerfile_scripts/scrape_libs.sh
@@ -36,7 +36,6 @@ then
        else 
 	       echo "libfabric not found within $host_dir." >&2
        fi # end if found libfabric.so
-   else echo "no suitable mounts available." >&2
    fi # end if /det_libfabric exists
    # See if we mounted in host libs in the expected location
 


### PR DESCRIPTION
### Before
```
karlon@pinoak-login1:/lus/scratch/karlon> grep mount ngc-25.03-py3-pt-hpc-f5052dc.log 
INFO:    underlay of /usr/bin/nvidia-smi required more than 50 (766) bind mounts
INFO:    underlay of /usr/bin/nvidia-smi required more than 50 (766) bind mounts
no suitable mounts available.
no suitable mounts available.
karlon@pinoak-login1:/lus/scratch/karlon>
```

### After
```
karlon@pinoak-login1:/lus/scratch/karlon> grep mount ngc-25.02-py3-pt-hpc-83b85fc.log 
INFO:    underlay of /usr/bin/nvidia-smi required more than 50 (766) bind mounts
INFO:    underlay of /usr/bin/nvidia-smi required more than 50 (766) bind mounts
karlon@pinoak-login1:/lus/scratch/karlon>
```