### PR TITLE
Update nccl-sanity to include support for cuda-13+

### DIFF
--- a/dockerfile_scripts/build_tests.sh
+++ b/dockerfile_scripts/build_tests.sh
@@ -21,6 +21,8 @@ then
     make -j8  MPI=1 MPI_HOME=${HPC_DIR} CUDA_HOME=${CUDA_DIR} NCCL_HOME=${HPC_DIR} BUILDDIR=${INSTALL_DIR}
     rm ${INSTALL_DIR}/*.o
     rm -rf ${INSTALL_DIR}/verifiable
+    ## Build tests/nccl-sanity.c
+    make -C ${SCRIPT_DIR}
 else
     INSTALL_DIR="${HPC_DIR}/tests/rccl-tests"
     mkdir -p ${INSTALL_DIR}


### PR DESCRIPTION
## Description
As of NGC-25.08, the NVidia container upgraded from CUDA-12.9 to CUDA-13.0.  Apparently, this broke a lot of dependencies according to the internet. As for `nccl-sanity.c`, CUDA-13 removed `computeMode` from `struct cudaDeviceProp{}` and replaced it with the new `cudaDeviceGetAttribute()` API.  This PR introduces some compile-time logic to *do the right thing(tm)* based on which version of CUDA is available in the container.

## Testing
Building on ngc-25.06, the following log output from compiling ncc-sanity shows
```
#25 124.6 make: Entering directory '/tmp/dockerfile_scripts'                                                                                      
#25 124.6 Compiling and Linking: nccl-sanity.c                                                                                                    
#25 124.6 mkdir -p /container/hpc/tests/nccl-tests                                                                                                
#25 124.6 nvcc -O2 -I/container/hpc/include nccl-sanity.c -o /container/hpc/tests/nccl-tests/nccl-sanity -L/container/hpc/lib -lmpi -lcudart -lncc
l                                                                                                                                                 
#25 124.7 nvcc warning : Support for offline compilation for architectures prior to '<compute/sm/lto>_75' will be removed in a future release (Use
 -Wno-deprecated-gpu-targets to suppress warning).                                                                                                
#25 125.1 Build complete: /container/hpc/tests/nccl-tests/nccl-sanity                                                                             
#25 125.1 make: Leaving directory '/tmp/dockerfile_scripts'           
```

The same build on ngc-25.08 produces:
```
#25 124.0 make: Entering directory '/tmp/dockerfile_scripts'                                                                                      
#25 124.0 Compiling and Linking: nccl-sanity.c                                                                                                    
#25 124.0 mkdir -p /container/hpc/tests/nccl-tests                                                                                                
#25 124.0 nvcc -O2 -I/container/hpc/include nccl-sanity.c -o /container/hpc/tests/nccl-tests/nccl-sanity -L/container/hpc/lib -lmpi -lcudart -lncc
l                                                                                                                                                 
#25 124.4 Build complete: /container/hpc/tests/nccl-tests/nccl-sanity                                                                             
#25 124.4 make: Leaving directory '/tmp/dockerfile_scripts'                                                                                       

```