### PR TITLE
Fix ROCm to support libfabric choice

### DIFF
--- a/Dockerfile-rocm-hpc
+++ b/Dockerfile-rocm-hpc
@@ -43,8 +43,9 @@ RUN ${SCRIPT_DIR}/install_deb_packages.sh
 # Install Cray CXI headers/lib
 COPY dockerfile_scripts/cray-libs.sh ${SCRIPT_DIR}
 ARG WITH_OFI
+ARG LIBFABRIC_VERSION
 RUN if [ "$WITH_OFI" = "1" ]; then \
-    ${SCRIPT_DIR}/cray-libs.sh ; \
+    ${SCRIPT_DIR}/cray-libs.sh "$LIBFABRIC_VERSION"; \
     fi
 
 #USING OFI

--- a/Makefile
+++ b/Makefile
@@ -393,6 +393,7 @@ build-pytorch-rocm:
 		--build-arg "WITH_PT=1" \
 		--build-arg "WITH_TF=0" \
 		--build-arg BASE_IMAGE="$(DOCKERHUB_REGISTRY)/$(ROCM_PYTORCH_REPO):$(SHORT_GIT_HASH)" \
+		--build-arg "LIBFABRIC_VERSION=$(LIBFABRIC_VERSION)" \
 		-t $(DOCKERHUB_REGISTRY)/$(ROCM_PYTORCH_HPC_REPO):$(SHORT_GIT_HASH) \
 		.
 ifeq "$(BUILD_SIF)" "1"
@@ -422,6 +423,7 @@ build-user-spec-rocm:
 		--build-arg "WITH_PT=1" \
 		--build-arg "WITH_TF=0" \
 		--build-arg BASE_IMAGE="$(USER_ROCM_BASE_IMAGE)" \
+		--build-arg "LIBFABRIC_VERSION=$(LIBFABRIC_VERSION)" \
 		-t $(USER_ROCM_IMAGE_HPC)\
 		.
 ifeq "$(BUILD_SIF)" "1"

--- a/dockerfile_scripts/build_tests.sh
+++ b/dockerfile_scripts/build_tests.sh
@@ -30,6 +30,10 @@ else
     RCCL_REPO="https://github.com/ROCm/rccl-tests.git"
     git clone --depth 1 ${RCCL_REPO}
     cd rccl-tests
+    if [[ ! -d /opt/rocm/rccl && -r /usr/local/lib/librccl.so ]]
+    then
+        export CUSTOM_RCCL_LIB=/usr/local/lib
+    fi
     make -j8  MPI=1 MPI_HOME=${HPC_DIR} BUILDDIR=${INSTALL_DIR}
     rm ${INSTALL_DIR}/*.o
     rm -rf ${INSTALL_DIR}/verifiable

--- a/dockerfile_scripts/cray-libs.sh
+++ b/dockerfile_scripts/cray-libs.sh
@@ -42,6 +42,14 @@ cd $cray_src_dir/shs-cxi-driver && \
 #cxi_cppflags="-Wno-unused-variable -Wno-unused-but-set-variable -g -O0"
 cxi_cflags="-Wno-unused-variable -Wno-unused-but-set-variable -I${HPC_DIR}/include -I${HPC_DIR}/linux -I${HPC_DIR}/uapi" 
 cxi_cppflags="-Wno-unused-variable -Wno-unused-but-set-variable -I${HPC_DIR}/include -I${HPC_DIR}/linux -I${HPC_DIR}/uapi"
+if [ -d "/opt/rocm" ] ; then
+    pkg-config --exists --print-errors "numa >= 2.0"
+    if [[ $? -ne 0 && -r /usr/include/numa.h ]]; then
+        echo "pkg-config failed (exit code: $?) but numa is installed"
+        export LIBNUMA_CFLAGS=/usr/include
+        export LIBNUMA_LIBS=-lnuma
+    fi
+fi
 cd $cray_src_dir/shs-libcxi && \
     git checkout -b release/shs-13.0 && \
     ./autogen.sh && \


### PR DESCRIPTION
This pull request updates the ROCm build sequence with the changes made in https://github.com/crickett-hpe/hpc-ai-envs/pull/40, which allows the user to choose the libfabric version at build time. 

Also addressed, is an Ubuntu-20.04 issue (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=991847) that some of the older ROCm images use, where the `Package Info` file for libnuma is not present, even though libnuma is installed. So, for ROCm builds, if the numa package is not present, but the `numa.h` header is, then update the LIBNUMA_CFLAGS and LIBNUMA_LIBS variables, to allow libcxi to build properly.

Lastly, some ROCm provided images, specifically the `rocm/vllm:rocm6.2_mi300_ubuntu20.04_py3.9_vllm_0.6.4` image AMD puts out for mlperf benchmarking that still supports MI250X gpus, do not have `RCCL` installed under `/opt/rocm` they way their newer images do. So, for ROCm buiilds, if `/opt/rocm/rccl` doesn't exist and `/usr/local/lib/librccl.so` does exist, update CUSTOM_RCCL_LIB appropriately.

The following image was built with:
```
make USE_CWD_SIF=1 BUILD_SIF=1 \
   USER_ROCM_BASE_IMAGE=rocm/vllm:rocm6.2_mi300_ubuntu20.04_py3.9_vllm_0.6.4 build-user-spec-rocm \
   2>&1 | tee build-pytorch-rocm.log
```

and tested on pinoak:
```
env SLURM_NOFEEDBACK=1 srun --exclusive --mpi=pmix_v5 -N 2 --ntasks-per-node=1 -p bardpeak \
      singularity run --rocm --bind /lus/scratch/karlon \
       rocm-vllm-rocm6.2_mi300_ubuntu20.04_py3.9_vllm_0.6.4.sif /lus/scratch/karlon/wrapper.sh \
       /container/hpc/tests/rccl-tests/all_reduce_perf -b 1G -e 2G -f 2 -g 8
```