### PR TITLE
Offline build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,3 @@ offline-sources/*
 !offline-sources/.gitkeep
 # Containers with added .debs installed for airgapped installation
 prep
-
-# Build-time snapshots of the base image's ENTRYPOINT/CMD, generated
-# by `make ngc PRESERVE_BASE_ENTRYPOINT=1` (or rocm). Always present
-# after the first build so the Dockerfile COPY step succeeds.
-.base-entrypoint
-.base-cmd

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@
 
 # Ignore output of audit script
 download*
+
+# Airgapped-build source cache — populated by audit-offline-requirements.sh
+# on the connected side. Directory must exist for the Dockerfile COPY.
+offline-sources/*
+!offline-sources/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ offline-sources/*
 !offline-sources/.gitkeep
 # Containers with added .debs installed for airgapped installation
 prep
+
+# Build-time snapshots of the base image's ENTRYPOINT/CMD, generated
+# by `make ngc PRESERVE_BASE_ENTRYPOINT=1` (or rocm). Always present
+# after the first build so the Dockerfile COPY step succeeds.
+.base-entrypoint
+.base-cmd

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 # Ignore tar files
 *.tar
 
+# Ignore output of audit script
+download*

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,14 @@ download*
 # on the connected side. Directory must exist for the Dockerfile COPY.
 offline-sources/*
 !offline-sources/.gitkeep
+
+# Build-time snapshots of the base image's ENTRYPOINT/CMD, generated
+# by `make ngc PRESERVE_BASE_ENTRYPOINT=1` (or rocm). Directory is
+# tracked (via .gitkeep) so the Dockerfile COPY step always succeeds
+# on a fresh clone; contents are gitignored so switching bases between
+# builds doesn't dirty the working tree.
+.base-capture/*
+!.base-capture/.gitkeep
+
 # Containers with added .debs installed for airgapped installation
 prep

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ download*
 # on the connected side. Directory must exist for the Dockerfile COPY.
 offline-sources/*
 !offline-sources/.gitkeep
+# Containers with added .debs installed for airgapped installation
+prep

--- a/Dockerfile-ngc-hpc
+++ b/Dockerfile-ngc-hpc
@@ -4,6 +4,13 @@ FROM ${BASE_IMAGE}
 ARG SCRIPT_DIR=/tmp/dockerfile_scripts/
 RUN mkdir -p ${SCRIPT_DIR}
 
+# Optional airgapped-build source cache. Populate offline-sources/{git,tar}/
+# on the connected side (see audit-offline-requirements.sh). For online
+# builds, leave the directory empty; the build_*.sh scripts fall through
+# to git-clone/wget when OFFLINE_SOURCES is unset or points at an empty dir.
+COPY offline-sources/ /offline-sources/
+ENV OFFLINE_SOURCES=/offline-sources
+
 # Remove the ompi/ucx, etc that is in the base image
 # Seems that the torch installed in the NGC image links against this.
 # Wonder if that will cause problems? We can have it use our OMPI but it

--- a/Dockerfile-ngc-hpc
+++ b/Dockerfile-ngc-hpc
@@ -127,14 +127,15 @@ RUN mkdir -p /container/bin && \
     cp ${SCRIPT_DIR}/scrape_libs.sh /container/bin
 
 # Optional: snapshot the base image's ENTRYPOINT/CMD so scrape_libs.sh
-# can replay it after setting up the HPC environment. The two files are
-# committed to the repo as empty placeholders and overwritten by the
-# Makefile's CAPTURE_BASE_ENTRYPOINT hook when built via
-# `make ngc PRESERVE_BASE_ENTRYPOINT=1`. A direct `docker build` (no
-# Makefile) leaves them empty, which the runtime check treats as a
-# no-op — preserving the pre-feature behavior.
+# can replay it after setting up the HPC environment. The .base-capture/
+# directory is tracked (via .gitkeep) but its contents are gitignored
+# and populated by the Makefile's CAPTURE_BASE_ENTRYPOINT hook when
+# built via `make ngc PRESERVE_BASE_ENTRYPOINT=1`. A direct `docker
+# build` (no Makefile) sees an empty directory; scrape_libs.sh's
+# non-empty-file check treats that as a no-op, preserving pre-feature
+# behavior.
 ARG PRESERVE_BASE_ENTRYPOINT=0
-COPY .base-entrypoint .base-cmd /container/etc/
+COPY .base-capture/ /container/etc/base-capture/
 ENV HPC_PRESERVE_BASE_ENTRYPOINT=${PRESERVE_BASE_ENTRYPOINT}
 
 ENTRYPOINT ["/container/bin/scrape_libs.sh"]

--- a/Dockerfile-ngc-hpc
+++ b/Dockerfile-ngc-hpc
@@ -127,9 +127,12 @@ RUN mkdir -p /container/bin && \
     cp ${SCRIPT_DIR}/scrape_libs.sh /container/bin
 
 # Optional: snapshot the base image's ENTRYPOINT/CMD so scrape_libs.sh
-# can replay it after setting up the HPC environment. Files are always
-# copied (may be empty) so this COPY step doesn't fail. The env var
-# gates the replay behavior at runtime.
+# can replay it after setting up the HPC environment. The two files are
+# committed to the repo as empty placeholders and overwritten by the
+# Makefile's CAPTURE_BASE_ENTRYPOINT hook when built via
+# `make ngc PRESERVE_BASE_ENTRYPOINT=1`. A direct `docker build` (no
+# Makefile) leaves them empty, which the runtime check treats as a
+# no-op — preserving the pre-feature behavior.
 ARG PRESERVE_BASE_ENTRYPOINT=0
 COPY .base-entrypoint .base-cmd /container/etc/
 ENV HPC_PRESERVE_BASE_ENTRYPOINT=${PRESERVE_BASE_ENTRYPOINT}

--- a/Dockerfile-ngc-hpc
+++ b/Dockerfile-ngc-hpc
@@ -125,6 +125,15 @@ RUN if [ "$WITH_MPI" = "1" ]; then \
 COPY dockerfile_scripts/scrape_libs.sh ${SCRIPT_DIR}
 RUN mkdir -p /container/bin && \
     cp ${SCRIPT_DIR}/scrape_libs.sh /container/bin
+
+# Optional: snapshot the base image's ENTRYPOINT/CMD so scrape_libs.sh
+# can replay it after setting up the HPC environment. Files are always
+# copied (may be empty) so this COPY step doesn't fail. The env var
+# gates the replay behavior at runtime.
+ARG PRESERVE_BASE_ENTRYPOINT=0
+COPY .base-entrypoint .base-cmd /container/etc/
+ENV HPC_PRESERVE_BASE_ENTRYPOINT=${PRESERVE_BASE_ENTRYPOINT}
+
 ENTRYPOINT ["/container/bin/scrape_libs.sh"]
 
 RUN rm -r /tmp/*

--- a/Dockerfile-rocm-hpc
+++ b/Dockerfile-rocm-hpc
@@ -117,6 +117,15 @@ RUN if [ "$WITH_MPI" = "1" ]; then \
 COPY dockerfile_scripts/scrape_libs.sh ${SCRIPT_DIR}
 RUN mkdir -p /container/bin && \
     cp ${SCRIPT_DIR}/scrape_libs.sh /container/bin
+
+# Optional: snapshot the base image's ENTRYPOINT/CMD so scrape_libs.sh
+# can replay it after setting up the HPC environment. Files are always
+# copied (may be empty) so this COPY step doesn't fail. The env var
+# gates the replay behavior at runtime.
+ARG PRESERVE_BASE_ENTRYPOINT=0
+COPY .base-entrypoint .base-cmd /container/etc/
+ENV HPC_PRESERVE_BASE_ENTRYPOINT=${PRESERVE_BASE_ENTRYPOINT}
+
 ENTRYPOINT ["/container/bin/scrape_libs.sh"]
 
 CMD ["/bin/bash"]

--- a/Dockerfile-rocm-hpc
+++ b/Dockerfile-rocm-hpc
@@ -119,9 +119,12 @@ RUN mkdir -p /container/bin && \
     cp ${SCRIPT_DIR}/scrape_libs.sh /container/bin
 
 # Optional: snapshot the base image's ENTRYPOINT/CMD so scrape_libs.sh
-# can replay it after setting up the HPC environment. Files are always
-# copied (may be empty) so this COPY step doesn't fail. The env var
-# gates the replay behavior at runtime.
+# can replay it after setting up the HPC environment. The two files are
+# committed to the repo as empty placeholders and overwritten by the
+# Makefile's CAPTURE_BASE_ENTRYPOINT hook when built via
+# `make rocm PRESERVE_BASE_ENTRYPOINT=1`. A direct `docker build` (no
+# Makefile) leaves them empty, which the runtime check treats as a
+# no-op — preserving the pre-feature behavior.
 ARG PRESERVE_BASE_ENTRYPOINT=0
 COPY .base-entrypoint .base-cmd /container/etc/
 ENV HPC_PRESERVE_BASE_ENTRYPOINT=${PRESERVE_BASE_ENTRYPOINT}

--- a/Dockerfile-rocm-hpc
+++ b/Dockerfile-rocm-hpc
@@ -119,14 +119,15 @@ RUN mkdir -p /container/bin && \
     cp ${SCRIPT_DIR}/scrape_libs.sh /container/bin
 
 # Optional: snapshot the base image's ENTRYPOINT/CMD so scrape_libs.sh
-# can replay it after setting up the HPC environment. The two files are
-# committed to the repo as empty placeholders and overwritten by the
-# Makefile's CAPTURE_BASE_ENTRYPOINT hook when built via
-# `make rocm PRESERVE_BASE_ENTRYPOINT=1`. A direct `docker build` (no
-# Makefile) leaves them empty, which the runtime check treats as a
-# no-op — preserving the pre-feature behavior.
+# can replay it after setting up the HPC environment. The .base-capture/
+# directory is tracked (via .gitkeep) but its contents are gitignored
+# and populated by the Makefile's CAPTURE_BASE_ENTRYPOINT hook when
+# built via `make rocm PRESERVE_BASE_ENTRYPOINT=1`. A direct `docker
+# build` (no Makefile) sees an empty directory; scrape_libs.sh's
+# non-empty-file check treats that as a no-op, preserving pre-feature
+# behavior.
 ARG PRESERVE_BASE_ENTRYPOINT=0
-COPY .base-entrypoint .base-cmd /container/etc/
+COPY .base-capture/ /container/etc/base-capture/
 ENV HPC_PRESERVE_BASE_ENTRYPOINT=${PRESERVE_BASE_ENTRYPOINT}
 
 ENTRYPOINT ["/container/bin/scrape_libs.sh"]

--- a/Makefile
+++ b/Makefile
@@ -221,19 +221,24 @@ sif: tar
 
 # Build an HPC container using the base image provided by the user.
 # Snapshot the base image's Entrypoint and Cmd into files in the build
-# context. Called by the ngc/rocm targets before `docker build`. When
-# PRESERVE_BASE_ENTRYPOINT=0 the files are truncated so the scrape_libs.sh
-# runtime check is a no-op.
+# context under .base-capture/. Called by the ngc/rocm targets before
+# `docker build`. When PRESERVE_BASE_ENTRYPOINT=0 the files are truncated
+# so the scrape_libs.sh runtime check is a no-op.
+#
+# .base-capture/ is a tracked directory (via .gitkeep) whose contents
+# are gitignored so switching bases between builds doesn't dirty the
+# working tree.
 #
 # Arg $(1): base image reference to inspect
 define CAPTURE_BASE_ENTRYPOINT
+	@mkdir -p .base-capture
 	@if [ "$(PRESERVE_BASE_ENTRYPOINT)" = "1" ]; then \
 	    echo "Snapshotting ENTRYPOINT/CMD from $(1)"; \
-	    $(DOCKER) inspect --format='{{range .Config.Entrypoint}}{{println .}}{{end}}' $(1) | sed '/^$$/d' > .base-entrypoint || : > .base-entrypoint; \
-	    $(DOCKER) inspect --format='{{range .Config.Cmd}}{{println .}}{{end}}'        $(1) | sed '/^$$/d' > .base-cmd        || : > .base-cmd; \
+	    $(DOCKER) inspect --format='{{range .Config.Entrypoint}}{{println .}}{{end}}' $(1) | sed '/^$$/d' > .base-capture/base-entrypoint || : > .base-capture/base-entrypoint; \
+	    $(DOCKER) inspect --format='{{range .Config.Cmd}}{{println .}}{{end}}'        $(1) | sed '/^$$/d' > .base-capture/base-cmd        || : > .base-capture/base-cmd; \
 	else \
-	    : > .base-entrypoint; \
-	    : > .base-cmd; \
+	    : > .base-capture/base-entrypoint; \
+	    : > .base-capture/base-cmd; \
 	fi
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -229,8 +229,8 @@ sif: tar
 define CAPTURE_BASE_ENTRYPOINT
 	@if [ "$(PRESERVE_BASE_ENTRYPOINT)" = "1" ]; then \
 	    echo "Snapshotting ENTRYPOINT/CMD from $(1)"; \
-	    $(DOCKER) inspect --format='{{range .Config.Entrypoint}}{{println .}}{{end}}' $(1) > .base-entrypoint || : > .base-entrypoint; \
-	    $(DOCKER) inspect --format='{{range .Config.Cmd}}{{println .}}{{end}}'        $(1) > .base-cmd        || : > .base-cmd; \
+	    $(DOCKER) inspect --format='{{range .Config.Entrypoint}}{{println .}}{{end}}' $(1) | sed '/^$$/d' > .base-entrypoint || : > .base-entrypoint; \
+	    $(DOCKER) inspect --format='{{range .Config.Cmd}}{{println .}}{{end}}'        $(1) | sed '/^$$/d' > .base-cmd        || : > .base-cmd; \
 	else \
 	    : > .base-entrypoint; \
 	    : > .base-cmd; \

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ export REGISTRY_REPO := hpc-ai-envs
 HOROVOD_GPU_OPERATIONS := NCCL
 BUILD_OPTS ?=
 
+# When set to 1, snapshot the base image's ENTRYPOINT and CMD at build
+# time and replay them from scrape_libs.sh at container start. This makes
+# the -hpc image a drop-in replacement for the base image — users can
+# invoke `podman run <hpc-image> <same args as base>` and get the same
+# behavior plus the Slingshot/HPC env setup. Default 0 preserves the
+# original behavior (user must supply the full command on `podman run`).
+PRESERVE_BASE_ENTRYPOINT ?= 0
+
 # Default to enabling MPI, OFI and SS11. Note that if we cannot
 # find the SS11 libs automatically and the user did not provide
 # a location we will not end up building the -ss version of the image.
@@ -212,6 +220,23 @@ sif: tar
 	if [ "$(RM_SIF_TAR)" = "1" ]; then rm -f "$(TARGET_NAME).tar"; fi
 
 # Build an HPC container using the base image provided by the user.
+# Snapshot the base image's Entrypoint and Cmd into files in the build
+# context. Called by the ngc/rocm targets before `docker build`. When
+# PRESERVE_BASE_ENTRYPOINT=0 the files are truncated so the scrape_libs.sh
+# runtime check is a no-op.
+#
+# Arg $(1): base image reference to inspect
+define CAPTURE_BASE_ENTRYPOINT
+	@if [ "$(PRESERVE_BASE_ENTRYPOINT)" = "1" ]; then \
+	    echo "Snapshotting ENTRYPOINT/CMD from $(1)"; \
+	    $(DOCKER) inspect --format='{{range .Config.Entrypoint}}{{println .}}{{end}}' $(1) > .base-entrypoint || : > .base-entrypoint; \
+	    $(DOCKER) inspect --format='{{range .Config.Cmd}}{{println .}}{{end}}'        $(1) > .base-cmd        || : > .base-cmd; \
+	else \
+	    : > .base-entrypoint; \
+	    : > .base-cmd; \
+	fi
+endef
+
 # This enables us to append the SS11 bits to an otherwise working
 # user image to make it easier for users to deploy their containers on SS11.
 .PHONY: ngc
@@ -221,6 +246,7 @@ ngc:
 	@echo "USER_NGC_IMAGE_NAME: $(USER_NGC_IMAGE_NAME)"
 	@echo "USER_NGC_IMAGE_VER: $(USER_NGC_IMAGE_VER)"
 	@echo "USER_NGC_IMAGE_HPC: $(USER_NGC_IMAGE_HPC)"
+	$(call CAPTURE_BASE_ENTRYPOINT,$(USER_NGC_BASE_IMAGE))
 	$(DOCKER) build -f Dockerfile-ngc-hpc $(BUILD_OPTS) \
 		--build-arg "$(NCCL_BUILD_ARG)" \
 		--build-arg "$(XCCL_BUILD_ARG)" \
@@ -232,6 +258,7 @@ ngc:
 		--build-arg "WITH_TF=0" \
 		--build-arg BASE_IMAGE="$(USER_NGC_BASE_IMAGE)" \
 		--build-arg "LIBFABRIC_VERSION=$(LIBFABRIC_VERSION)" \
+		--build-arg "PRESERVE_BASE_ENTRYPOINT=$(PRESERVE_BASE_ENTRYPOINT)" \
 		-t $(USER_NGC_IMAGE_HPC)\
 		.
 
@@ -246,6 +273,7 @@ rocm:
 	@echo "USER_ROCM_IMAGE_NAME: $(USER_ROCM_IMAGE_NAME)"
 	@echo "USER_ROCM_IMAGE_VER: $(USER_ROCM_IMAGE_VER)"
 	@echo "USER_ROCM_IMAGE_HPC: $(USER_ROCM_IMAGE_HPC)"
+	$(call CAPTURE_BASE_ENTRYPOINT,$(USER_ROCM_BASE_IMAGE))
 	$(DOCKER) build -f Dockerfile-rocm-hpc $(BUILD_OPTS) \
 		--build-arg "$(NCCL_BUILD_ARG)" \
 		--build-arg "$(XCCL_BUILD_ARG)" \
@@ -257,5 +285,6 @@ rocm:
 		--build-arg "WITH_TF=0" \
 		--build-arg BASE_IMAGE="$(USER_ROCM_BASE_IMAGE)" \
 		--build-arg "LIBFABRIC_VERSION=$(LIBFABRIC_VERSION)" \
+		--build-arg "PRESERVE_BASE_ENTRYPOINT=$(PRESERVE_BASE_ENTRYPOINT)" \
 		-t $(USER_ROCM_IMAGE_HPC)\
 		.

--- a/audit-offline-requirements.sh
+++ b/audit-offline-requirements.sh
@@ -1,0 +1,377 @@
+#!/bin/bash
+# audit-offline-requirements.sh
+#
+# Run on the AIRGAPPED target where hpc-ai-envs is checked out. Doesn't
+# download or install anything — produces a report of what's needed for
+# an offline build.
+#
+# Usage:
+#   ./audit-offline-requirements.sh [-v|--verbose] [-s|--self] <hpc-ai-envs-checkout-dir>
+#
+# Modes:
+#   (default)    Concise SYSADMIN list: bare `git clone` and `wget` commands
+#                for the site-dependent (Slingshot-version-tied) sources to
+#                fetch on a connected system. Suitable to hand to sysadmins.
+#   -s, --self   Concise DEVELOPER report: the prep-base-image Dockerfile
+#                approach, showing what to pre-bake into the container image
+#                (SS-independent) vs what to ship as a small on-site source
+#                bundle (SS-version-tied).
+#   -v, --verbose  Full detail: OS-level requirements on airgapped build host,
+#                version pins, raw URL and apt-get extracts, .deb list,
+#                bundle assembly layout, host SHS package inventory.
+
+set -eu
+
+VERBOSE=0
+SELF=0
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -v|--verbose) VERBOSE=1; shift ;;
+        -s|--self)    SELF=1; shift ;;
+        -h|--help)
+            # Print only the leading header comment block (skip shebang, stop at first blank line)
+            awk 'NR==1 && /^#!/{next} /^#/{sub(/^# ?/,""); print; next} /^$/{exit}' "$0"
+            exit 0 ;;
+        --) shift; break ;;
+        -*) echo "Unknown option: $1" >&2; exit 2 ;;
+        *)  POSITIONAL+=("$1"); shift ;;
+    esac
+done
+set -- "${POSITIONAL[@]:-}"
+
+HPC_AI_ENVS="${1:?Usage: $0 [-v|--verbose|-s|--self] <hpc-ai-envs-checkout-dir>}"
+DFS="$HPC_AI_ENVS/dockerfile_scripts"
+
+if [ ! -d "$HPC_AI_ENVS" ]; then
+    echo "ERROR: not a directory: $HPC_AI_ENVS" >&2
+    exit 1
+fi
+
+# --- Detect version pins from the source tree ------------------------------
+get() { grep -m1 "$2" "$1" 2>/dev/null | head -1 | sed -E 's/.*=[[:space:]]*"?([^"[:space:]]+)"?.*/\1/'; }
+
+BASE_IMAGE_DEFAULT="docker.io/vllm/vllm-openai:v0.23.0-aarch64-cu129-ubuntu2404"
+BASE_IMAGE="${BASE_IMAGE:-$BASE_IMAGE_DEFAULT}"
+
+SHS_VERSION=$(get "$DFS/cray-libs.sh" '^SHS_VERSION=')
+LIBFABRIC_VERSION=$(grep -m1 '^LIBFABRIC_VERSION' "$HPC_AI_ENVS/Makefile" | sed -E 's/.*[:=]+[[:space:]]*//')
+PMIX_VERSION=$(grep -m1 'PMIX_VERSION=' "$DFS/build_pmix.sh" | sed -E 's/.*:-([0-9.]+).*/\1/')
+OMPI_VER=$(get "$DFS/ompi.sh" 'OMPI_VER_NUM=')
+AWS_VER=$(get "$DFS/build_aws.sh" '^AWS_VER_NUM=')
+NCCL_TESTS_VER=$(get "$DFS/build_tests.sh" 'NCCL_VER=')
+OSU_VER=$(get "$DFS/build_tests.sh" 'OSU_VER=')
+
+# --- Derived URLs ----------------------------------------------------------
+OMPI_MAJOR_MINOR="${OMPI_VER%.*}"
+URL_LIBFABRIC="https://github.com/ofiwg/libfabric/releases/download/v${LIBFABRIC_VERSION}/libfabric-${LIBFABRIC_VERSION}.tar.bz2"
+URL_PMIX="https://github.com/openpmix/openpmix/releases/download/v${PMIX_VERSION}/pmix-${PMIX_VERSION}.tar.gz"
+URL_OMPI="https://download.open-mpi.org/release/open-mpi/v${OMPI_MAJOR_MINOR}/openmpi-${OMPI_VER}.tar.gz"
+URL_AWS="https://github.com/aws/aws-ofi-nccl/releases/download/v${AWS_VER}/aws-ofi-nccl-${AWS_VER}.tar.gz"
+URL_OSU="https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-${OSU_VER}.tar.gz"
+
+# --- Auto-extract deb list from build scripts ------------------------------
+DEB_LIST=$(awk '/\\$/{sub(/\\$/,""); printf "%s ", $0; next} {print}' \
+    "$HPC_AI_ENVS/Dockerfile-ngc-hpc" \
+    "$DFS"/*.sh 2>/dev/null \
+  | grep -oE 'apt-get install[^;&|]*' \
+  | sed -E 's/apt-get install//; s/-y|--no-install-recommends|-o [^ ]+|DEBIAN_FRONTEND=[^ ]+//g' \
+  | tr ' ' '\n' \
+  | grep -E '^[a-z0-9][a-z0-9._+-]*$' \
+  | grep -vE '^(true|false)$' \
+  | sort -u)
+
+# ============================================================================
+#   MODE: concise sysadmin (default)
+#   Just the site-dependent fetch commands, shell-ready.
+# ============================================================================
+if [ "$VERBOSE" -eq 0 ] && [ "$SELF" -eq 0 ]; then
+cat <<EOF
+#!/bin/bash
+# hpc-ai-envs offline source fetch — run on a connected system
+set -eu
+
+git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-cassini-headers.git
+git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-cxi-driver.git
+git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-libcxi.git
+git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-libfabric.git
+git clone --depth 1 -b ${NCCL_TESTS_VER:-<unset>} https://github.com/NVIDIA/nccl-tests.git
+
+wget $URL_LIBFABRIC
+wget $URL_OMPI
+wget $URL_AWS
+wget $URL_OSU
+EOF
+exit 0
+fi
+
+# ============================================================================
+#   MODE: concise self (developer prep-base approach)
+# ============================================================================
+if [ "$SELF" -eq 1 ] && [ "$VERBOSE" -eq 0 ]; then
+cat <<EOF
+================================================================
+  hpc-ai-envs offline build — self / developer view
+  Checkout: $HPC_AI_ENVS
+================================================================
+
+STRATEGY: Pre-bake Slingshot-INDEPENDENT parts into a prepared base image on
+the connected side. Only ship SS-version-tied source and a small bundle
+to the airgapped side.
+
+--- Version pins (auto-detected) ---
+  BASE_IMAGE         = $BASE_IMAGE
+  SHS_VERSION        = ${SHS_VERSION:-<unset>}
+  LIBFABRIC_VERSION  = ${LIBFABRIC_VERSION:-<unset>}
+  PMIX_VERSION       = ${PMIX_VERSION:-<unset>}
+  OMPI_VER           = ${OMPI_VER:-<unset>}
+  AWS_VER            = ${AWS_VER:-<unset>}
+  NCCL_TESTS_VER     = ${NCCL_TESTS_VER:-<unset>}
+  OSU_VER            = ${OSU_VER:-<unset>}
+
+============================================================
+  Bake into the prepared base image (SS-independent)
+============================================================
+Build once on a connected system, save as vllm-prepared.tar, ship over.
+
+Dockerfile.vllm-prepared:
+
+  FROM $BASE_IMAGE
+
+  # All apt packages the build scripts install (auto-extracted)
+  RUN apt-get update && apt-get install -y --no-install-recommends \\
+$(echo "$DEB_LIST" | awk '{if(NR>1)print prev" \\\\"; prev="        "$0} END{if(prev!="")print prev}')
+      && rm -rf /var/lib/apt/lists/*
+
+  # Pre-build PMIx (no Slingshot dep)
+  ARG PMIX_VERSION=${PMIX_VERSION:-5.0.3}
+  RUN cd /tmp && wget -q $URL_PMIX && \\
+      tar xzf pmix-\${PMIX_VERSION}.tar.gz && cd pmix-\${PMIX_VERSION} && \\
+      ./configure --prefix=/container/hpc --with-libevent --with-hwloc && \\
+      make -j\$(nproc) && make install && cd / && rm -rf /tmp/pmix-*
+
+  # Pre-build NCCL (no Slingshot dep; network plugin comes later)
+  RUN git clone --depth 1 https://github.com/NVIDIA/nccl.git /tmp/nccl && \\
+      cd /tmp/nccl && \\
+      make -j\$(nproc) src.build CUDA_HOME=/usr/local/cuda BUILDDIR=/container/nccl && \\
+      cd / && rm -rf /tmp/nccl
+
+  # Blank sources.list so 'apt-get update' on airgapped side is a no-op
+  RUN > /etc/apt/sources.list && \\
+      rm -rf /etc/apt/sources.list.d/* && \\
+      apt-get update
+
+  ENV PATH=/container/nccl/bin:\$PATH \\
+      LD_LIBRARY_PATH=/container/hpc/lib:/container/nccl/lib:\$LD_LIBRARY_PATH \\
+      NCCL_HOME=/container/nccl \\
+      PMIX_HOME=/container/hpc
+
+Build & save:
+
+  podman build -f Dockerfile.vllm-prepared -t vllm-prepared:v0.23.0 .
+  podman save -o vllm-prepared.tar vllm-prepared:v0.23.0
+
+Use as USER_IMAGE on the airgapped side (skips apt work + NCCL + PMIx):
+
+  podman load -i vllm-prepared.tar
+  make ngc USER_IMAGE=vllm-prepared:v0.23.0 DOCKER=podman
+
+============================================================
+  Ship separately (SS-version-tied source bundle)
+============================================================
+
+Small source bundle (~50 MB) for on-site compilation against target SHS.
+
+  git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-cassini-headers.git
+  git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-cxi-driver.git
+  git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-libcxi.git
+  git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-libfabric.git
+  git clone --depth 1 -b ${NCCL_TESTS_VER:-<unset>} https://github.com/NVIDIA/nccl-tests.git
+
+  wget $URL_LIBFABRIC
+  wget $URL_OMPI
+  wget $URL_AWS
+  wget $URL_OSU
+
+Package layout:
+
+  offline-bundle/
+    base-image/vllm-prepared.tar          (from Dockerfile above)
+    git/{shs-*,nccl-tests}/               (branch-pinned)
+    tar/{libfabric,openmpi,aws-ofi-nccl,osu}.tar.*
+
+  tar czf offline-bundle.tgz offline-bundle/
+
+============================================================
+  On-site (airgapped) workflow
+============================================================
+
+  cd hpc-ai-envs
+  tar xzf offline-bundle.tgz
+  ln -s offline-bundle offline-sources        # patched scripts prefer this
+  podman load -i offline-bundle/base-image/vllm-prepared.tar
+
+  WITH_MPI=1 WITH_OFI=1 WITH_NCCL=1 MPI_TYPE=openmpi \\
+    make ngc USER_IMAGE=vllm-prepared:v0.23.0 DOCKER=podman 2>&1 | tee build.log
+
+EOF
+exit 0
+fi
+
+# ============================================================================
+#   MODE: verbose
+# ============================================================================
+cat <<EOF
+================================================================
+  hpc-ai-envs offline build — requirements audit (verbose)
+  Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+  Checkout:  $HPC_AI_ENVS
+================================================================
+
+================================================================
+  1. HOST OS PACKAGES REQUIRED ON THE AIRGAPPED BUILD HOST
+================================================================
+
+These must be installed on the build host itself (not the container):
+
+  podman           - container build engine
+  git              - to check out the hpc-ai-envs sources
+  tar / gzip       - to unpack the offline bundle
+  make             - to invoke the Makefile targets
+  coreutils        - basic tools (mktemp, install, etc.)
+
+Optional but useful:
+  apptainer or singularity  - only if converting the built image to .sif
+                              for WLM-based execution
+
+Slingshot userspace (already present per SHS install, listed for reference):
+$(rpm -qa 2>/dev/null | grep -iE "cxi|cassini|slingshot|shs|libfabric" | sort | sed 's/^/  /' || \
+  dpkg -l 2>/dev/null | grep -iE "cxi|cassini|slingshot|shs|libfabric" | sed 's/^/  /' || \
+  echo "  (no rpm/dpkg available or no SHS packages found)")
+
+Kernel & OS:
+  $(uname -r)   $(grep -m1 PRETTY_NAME /etc/os-release 2>/dev/null | cut -d= -f2 | tr -d '"' || echo unknown)
+
+================================================================
+  2. FILES TO DOWNLOAD ON A CONNECTED SYSTEM AND SHIP OVER
+================================================================
+
+Detected version pins from checkout:
+  BASE_IMAGE         = $BASE_IMAGE
+  SHS_VERSION        = ${SHS_VERSION:-<unset>}       (branch of shs-* repos)
+  LIBFABRIC_VERSION  = ${LIBFABRIC_VERSION:-<unset>}
+  PMIX_VERSION       = ${PMIX_VERSION:-<unset>}
+  OMPI_VER           = ${OMPI_VER:-<unset>}
+  AWS_VER            = ${AWS_VER:-<unset>}
+  NCCL_TESTS_VER     = ${NCCL_TESTS_VER:-<unset>}
+  OSU_VER            = ${OSU_VER:-<unset>}
+
+--- 2a. Base container image (podman save on connected side) ---
+  $BASE_IMAGE
+    -> Fetch with: podman pull $BASE_IMAGE
+    -> Save with:  podman save -o vllm-base.tar $BASE_IMAGE
+
+--- 2b. Git repos to clone (shallow --depth 1 is sufficient) ---
+  https://github.com/HewlettPackard/shs-cassini-headers.git   (branch: ${SHS_VERSION:-release/shs-14.0.0})
+  https://github.com/HewlettPackard/shs-cxi-driver.git        (branch: ${SHS_VERSION:-release/shs-14.0.0})
+  https://github.com/HewlettPackard/shs-libcxi.git            (branch: ${SHS_VERSION:-release/shs-14.0.0})
+  https://github.com/HewlettPackard/shs-libfabric.git         (branch: ${SHS_VERSION:-release/shs-14.0.0})
+  https://github.com/NVIDIA/nccl.git                          (main)
+  https://github.com/NVIDIA/nccl-tests.git                    (tag: ${NCCL_TESTS_VER:-v2.15.0})
+
+--- 2c. Source tarballs to wget ---
+  https://github.com/ofiwg/libfabric/releases/download/v${LIBFABRIC_VERSION:-2.3.1}/libfabric-${LIBFABRIC_VERSION:-2.3.1}.tar.bz2
+  https://github.com/openpmix/openpmix/releases/download/v${PMIX_VERSION:-5.0.3}/pmix-${PMIX_VERSION:-5.0.3}.tar.gz
+  https://download.open-mpi.org/release/open-mpi/v${OMPI_VER%.*}/openmpi-${OMPI_VER:-<see-ompi.sh>}.tar.gz
+  https://github.com/aws/aws-ofi-nccl/releases/download/v${AWS_VER:-<see-build_aws.sh>}/aws-ofi-nccl-${AWS_VER:-<see>}.tar.gz
+  https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-${OSU_VER:-<see-build_tests.sh>}.tar.gz
+
+--- 2d. .deb packages that get installed INTO the container ---
+Union of every 'apt-get install' across Dockerfile-ngc-hpc and
+dockerfile_scripts/*.sh. Auto-extracted from the checkout:
+
+$(awk '/\\$/{sub(/\\$/,""); printf "%s ", \$0; next} {print}' \
+    "$HPC_AI_ENVS/Dockerfile-ngc-hpc" \
+    "$DFS"/*.sh 2>/dev/null \
+  | grep -oE 'apt-get install[^;&|]*' \
+  | sed -E 's/apt-get install//; s/-y|--no-install-recommends|-o [^ ]+|DEBIAN_FRONTEND=[^ ]+//g' \
+  | tr ' ' '\n' \
+  | grep -E '^[a-z0-9][a-z0-9._+-]*\$' \
+  | grep -vE '^(true|false)\$' \
+  | sort -u \
+  | sed 's/^/  /')
+
+Fetch these inside the same base image so arch/versions match. On the
+connected system:
+
+  mkdir debs
+  podman run --rm -v \$PWD/debs:/debs \\
+    $BASE_IMAGE \\
+    bash -c "apt-get update && \\
+             apt-get install -y --no-install-recommends --download-only \\
+               -o Dir::Cache::archives=/debs \\
+               \$(<list-of-packages-above>)"
+
+Then ship debs/ over as part of the bundle.
+
+NOTE: cuda-nvml-dev-12-9 (from developer.download.nvidia.com/compute/cuda)
+requires the NVIDIA CUDA apt repo to already be configured in the base
+image. The vLLM/NGC base images ship with it configured. If it's not there,
+add libnvidia-ml-dev from Ubuntu universe as a fallback.
+
+================================================================
+  3. RAW EXTRACT FROM SCRIPTS (for verification / reproducibility)
+================================================================
+
+--- URLs referenced in the build scripts ---
+$(awk '/\\$/{sub(/\\$/,""); printf "%s", \$0; next} {print}' \
+    "$HPC_AI_ENVS/Dockerfile-ngc-hpc" \
+    "$HPC_AI_ENVS/Makefile" \
+    "$DFS"/*.sh 2>/dev/null \
+  | grep -oE 'https?://[^" '"'"']+' \
+  | grep -vE '^https?://(hub\.docker\.com|github\.com/ROCm|github\.com/thomas-bouvier)' \
+  | sort -u \
+  | sed 's/^/  /')
+
+--- apt-get commands referenced ---
+$(awk '/\\$/{sub(/\\$/,""); printf "%s", \$0; next} {print}' \
+    "$HPC_AI_ENVS/Dockerfile-ngc-hpc" \
+    "$DFS"/*.sh 2>/dev/null \
+  | grep -E 'apt-get (install|update)' \
+  | grep -v '^\s*#' \
+  | sed 's/^/  /' \
+  | head -20)
+
+================================================================
+  4. ASSEMBLY LAYOUT (for the shipped bundle)
+================================================================
+
+On the connected system, produce a bundle with this layout:
+
+  offline-bundle/
+    base-image/
+      vllm-base.tar                    (podman save output)
+    git/
+      shs-cassini-headers/             (git clone --depth 1 -b <SHS_VERSION>)
+      shs-cxi-driver/
+      shs-libcxi/
+      shs-libfabric/
+      nccl/
+      nccl-tests/                      (branch ${NCCL_TESTS_VER:-v2.15.0})
+    tar/
+      libfabric-*.tar.bz2
+      pmix-*.tar.gz
+      openmpi-*.tar.gz
+      aws-ofi-nccl-*.tar.gz
+      osu-micro-benchmarks-*.tar.gz
+    debs/
+      *.deb
+
+  Then: tar czf offline-bundle.tgz offline-bundle/
+
+On the airgapped system, extract to \$HPC_AI_ENVS/offline-sources/ and apply
+the offline-helper.sh patches so cray-libs.sh / ompi.sh / build_pmix.sh /
+build_aws.sh / build_tests.sh check /offline-sources/ before hitting the
+network.
+
+EOF

--- a/audit-offline-requirements.sh
+++ b/audit-offline-requirements.sh
@@ -61,11 +61,13 @@ OMPI_VER=$(get "$DFS/ompi.sh" 'OMPI_VER_NUM=')
 AWS_VER=$(get "$DFS/build_aws.sh" '^AWS_VER_NUM=')
 NCCL_TESTS_VER=$(get "$DFS/build_tests.sh" 'NCCL_VER=')
 OSU_VER=$(get "$DFS/build_tests.sh" 'OSU_VER=')
+NCCL_VER=$(get "$DFS/build_nccl.sh" 'git checkout' | awk '{print $NF}' | tr -d ')')
+PMIX_VERSION_DFL=$(get "$DFS/build_pmix.sh" 'PMIX_VERSION=')
 
 # --- Derived URLs ----------------------------------------------------------
 OMPI_MAJOR_MINOR="${OMPI_VER%.*}"
 URL_LIBFABRIC="https://github.com/ofiwg/libfabric/releases/download/v${LIBFABRIC_VERSION}/libfabric-${LIBFABRIC_VERSION}.tar.bz2"
-URL_PMIX="https://github.com/openpmix/openpmix/releases/download/v${PMIX_VERSION}/pmix-${PMIX_VERSION}.tar.gz"
+URL_PMIX="https://github.com/openpmix/openpmix/releases/download/v${PMIX_VERSION:-$PMIX_VERSION_DFL}/pmix-${PMIX_VERSION:-$PMIX_VERSION_DFL}.tar.gz"
 URL_OMPI="https://download.open-mpi.org/release/open-mpi/v${OMPI_MAJOR_MINOR}/openmpi-${OMPI_VER}.tar.gz"
 URL_AWS="https://github.com/aws/aws-ofi-nccl/releases/download/v${AWS_VER}/aws-ofi-nccl-${AWS_VER}.tar.gz"
 URL_OSU="https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-${OSU_VER}.tar.gz"
@@ -88,19 +90,30 @@ DEB_LIST=$(awk '/\\$/{sub(/\\$/,""); printf "%s ", $0; next} {print}' \
 if [ "$VERBOSE" -eq 0 ] && [ "$SELF" -eq 0 ]; then
 cat <<EOF
 #!/bin/bash
-# hpc-ai-envs offline source fetch — run on a connected system
+# hpc-ai-envs offline source fetch — run on a connected system.
+# Produces ./offline-sources/{git,tar}/ ready to drop into the
+# hpc-ai-envs checkout root before building.
 set -eu
+
+mkdir -p offline-sources/git offline-sources/tar
+cd offline-sources/git
 
 git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-cassini-headers.git
 git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-cxi-driver.git
 git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-libcxi.git
 git clone --depth 1 -b ${SHS_VERSION:-<unset>} https://github.com/HewlettPackard/shs-libfabric.git
 git clone --depth 1 -b ${NCCL_TESTS_VER:-<unset>} https://github.com/NVIDIA/nccl-tests.git
+git clone https://github.com/nvidia/nccl.git
+( cd nccl && git checkout ${NCCL_VER:-<unset>} )
 
+cd ../tar
 wget $URL_LIBFABRIC
+wget $URL_PMIX
 wget $URL_OMPI
 wget $URL_AWS
 wget $URL_OSU
+
+echo "Done. Copy ./offline-sources/ into the hpc-ai-envs checkout root."
 EOF
 exit 0
 fi
@@ -138,9 +151,14 @@ Dockerfile.vllm-prepared:
 
   FROM $BASE_IMAGE
 
-  # All apt packages the build scripts install (auto-extracted)
+  # cuda-nvml-dev provides nvml.h — libfabric's hmem_cuda code needs it
+  # (auto-detected in the vLLM base image; missing header breaks build later)
   RUN apt-get update && apt-get install -y --no-install-recommends \\
-$(echo "$DEB_LIST" | awk '{if(NR>1)print prev" \\\\"; prev="        "$0} END{if(prev!="")print prev}')
+      cuda-nvml-dev-12-9 && rm -rf /var/lib/apt/lists/*
+
+  # All other apt packages the build scripts install (auto-extracted)
+  RUN apt-get update && apt-get install -y --no-install-recommends \\
+$(echo "$DEB_LIST" | awk '{if(NR>1)print prev" \\"; prev="        "$0} END{if(prev!="")print prev}')
       && rm -rf /var/lib/apt/lists/*
 
   # Pre-build PMIx (no Slingshot dep)

--- a/dockerfile_scripts/build_aws.sh
+++ b/dockerfile_scripts/build_aws.sh
@@ -17,8 +17,8 @@ apt-get update \
 				      --no-install-recommends tcsh
 
 # Install AWS_OFI_NCCL
-AWS_VER=v1.16.3
-AWS_VER_NUM=1.16.3
+AWS_VER=v1.20.0
+AWS_VER_NUM=1.20.0
 AWS_NAME=aws-ofi-nccl
 AWS_FILE="${AWS_NAME}-${AWS_VER_NUM}"
 cuda_ver_str=`echo $CUDA_VERSION | awk -F "." '{print $1"."$2}'`

--- a/dockerfile_scripts/build_aws.sh
+++ b/dockerfile_scripts/build_aws.sh
@@ -69,7 +69,12 @@ then
         git checkout v1.14.x-xccl
     else
         ###export CC=g++
-        wget ${AWS_URL}
+        if [ -n "${OFFLINE_SOURCES:-}" ] && [ -f "${OFFLINE_SOURCES}/tar/${AWS_NAME}.tar.gz" ]; then
+            echo "build_aws: using offline ${AWS_NAME}.tar.gz"
+            cp "${OFFLINE_SOURCES}/tar/${AWS_NAME}.tar.gz" .
+        else
+            wget ${AWS_URL}
+        fi
         tar -xzf ${AWS_NAME}.tar.gz --no-same-owner
         cd ${AWS_NAME}
 

--- a/dockerfile_scripts/build_nccl.sh
+++ b/dockerfile_scripts/build_nccl.sh
@@ -4,10 +4,14 @@ set -x
 
 cuda_ver_str=`echo $CUDA_VERSION | awk -F "." '{print $1"."$2}'`
 CUDA_DIR="/usr/local/cuda-$cuda_ver_str"
-    
-git clone https://github.com/nvidia/nccl.git /tmp/nccl_src
 
-(cd /tmp/nccl_src && git checkout v2.27.7-1)
+if [ -n "${OFFLINE_SOURCES:-}" ] && [ -d "${OFFLINE_SOURCES}/git/nccl" ]; then
+    echo "build_nccl: using offline nccl repo"
+    cp -r ${OFFLINE_SOURCES}/git/nccl /tmp/nccl_src
+else
+    git clone https://github.com/nvidia/nccl.git /tmp/nccl_src
+    (cd /tmp/nccl_src && git checkout v2.27.7-1)
+fi
 
 ## Cuda Compute Capability
 ## 8.0: A100, A30

--- a/dockerfile_scripts/build_pmix.sh
+++ b/dockerfile_scripts/build_pmix.sh
@@ -36,7 +36,12 @@ echo "Using LIBDIR=$LIBDIR"
 mkdir -p ${PMIX_SRC_DIR}
 cd ${PMIX_SRC_DIR}
 
-wget ${PMIX_URL}
+if [ -n "${OFFLINE_SOURCES:-}" ] && [ -f "${OFFLINE_SOURCES}/tar/pmix-${PMIX_VERSION}.tar.gz" ]; then
+    echo "build_pmix: using offline pmix-${PMIX_VERSION}.tar.gz"
+    cp "${OFFLINE_SOURCES}/tar/pmix-${PMIX_VERSION}.tar.gz" .
+else
+    wget ${PMIX_URL}
+fi
 tar -xzf pmix-${PMIX_VERSION}.tar.gz
 cd pmix-${PMIX_VERSION}
 

--- a/dockerfile_scripts/build_tests.sh
+++ b/dockerfile_scripts/build_tests.sh
@@ -30,7 +30,10 @@ then
     make -C ${SCRIPT_DIR}
 
     ## OSU Benchmark Configuration Option
-    OSU_CONFIG="--enable-cuda --with-cuda-include=/usr/local/cuda/include --with-cuda-libpath=/usr/local/cuda/lib64"
+    ## libcuda.so is provided by the driver at runtime; at build time
+    ## it only exists in the CUDA toolkit's stubs directory. Point
+    ## configure there so linking succeeds inside the container.
+    OSU_CONFIG="--enable-cuda --with-cuda-include=${CUDA_DIR}/include --with-cuda-libpath=${CUDA_DIR}/lib64/stubs"
 else
     INSTALL_DIR="${HPC_DIR}/tests/rccl-tests"
     mkdir -p ${INSTALL_DIR}

--- a/dockerfile_scripts/build_tests.sh
+++ b/dockerfile_scripts/build_tests.sh
@@ -16,7 +16,12 @@ then
 
     NCCL_VER="v2.15.0"
     NCCL_REPO="https://github.com/NVIDIA/nccl-tests.git"
-    git clone --depth 1 --branch ${NCCL_VER} ${NCCL_REPO}
+    if [ -n "${OFFLINE_SOURCES:-}" ] && [ -d "${OFFLINE_SOURCES}/git/nccl-tests" ]; then
+        echo "build_tests: using offline nccl-tests"
+        cp -r ${OFFLINE_SOURCES}/git/nccl-tests .
+    else
+        git clone --depth 1 --branch ${NCCL_VER} ${NCCL_REPO}
+    fi
     cd nccl-tests
     make -j8  MPI=1 MPI_HOME=${HPC_DIR} CUDA_HOME=${CUDA_DIR} NCCL_HOME=${HPC_DIR} BUILDDIR=${INSTALL_DIR}
     rm ${INSTALL_DIR}/*.o
@@ -51,7 +56,12 @@ fi
 OSU_VER=7.5.2
 cd ${TDIR}
 OSU_REPO="https://mvapich.cse.ohio-state.edu/download/mvapich"
-wget ${OSU_REPO}/osu-micro-benchmarks-${OSU_VER}.tar.gz
+if [ -n "${OFFLINE_SOURCES:-}" ] && [ -f "${OFFLINE_SOURCES}/tar/osu-micro-benchmarks-${OSU_VER}.tar.gz" ]; then
+    echo "build_tests: using offline osu-micro-benchmarks-${OSU_VER}.tar.gz"
+    cp "${OFFLINE_SOURCES}/tar/osu-micro-benchmarks-${OSU_VER}.tar.gz" .
+else
+    wget ${OSU_REPO}/osu-micro-benchmarks-${OSU_VER}.tar.gz
+fi
 tar -xzf osu-micro-benchmarks-${OSU_VER}.tar.gz --no-same-owner
 cd osu-micro-benchmarks-${OSU_VER}
 ./configure CC=${HPC_DIR}/bin/mpicc CXX=${HPC_DIR}/bin/mpicxx \

--- a/dockerfile_scripts/cray-libs.sh
+++ b/dockerfile_scripts/cray-libs.sh
@@ -17,12 +17,21 @@ SHS_VERSION="release/shs-13.0.0"
 # Install Cray libcxi. This requires grabbing the cassini/cxi headers
 # and installing them into ${HPC_DIR} so we can compile libcxi.
 cray_src_dir=/tmp/cray-libs
-mkdir -p $cray_src_dir && \
-    cd $cray_src_dir && \
+mkdir -p $cray_src_dir
+cd $cray_src_dir
+
+if [ -n "${OFFLINE_SOURCES:-}" ] && [ -d "${OFFLINE_SOURCES}/git/shs-libfabric" ]; then
+    echo "cray-libs: using offline sources from ${OFFLINE_SOURCES}/git"
+    cp -r ${OFFLINE_SOURCES}/git/shs-cassini-headers .
+    cp -r ${OFFLINE_SOURCES}/git/shs-cxi-driver .
+    cp -r ${OFFLINE_SOURCES}/git/shs-libcxi .
+    cp -r ${OFFLINE_SOURCES}/git/shs-libfabric .
+else
     git clone https://github.com/HewlettPackard/shs-cassini-headers.git && \
-    git clone https://github.com/HewlettPackard/shs-cxi-driver.git && \
-    git clone https://github.com/HewlettPackard/shs-libcxi.git && \
-    git clone https://github.com/HewlettPackard/shs-libfabric.git
+        git clone https://github.com/HewlettPackard/shs-cxi-driver.git && \
+        git clone https://github.com/HewlettPackard/shs-libcxi.git && \
+        git clone https://github.com/HewlettPackard/shs-libfabric.git
+fi
 
 # Install the cassini headers
 cd $cray_src_dir/shs-cassini-headers && \
@@ -111,11 +120,15 @@ else
   LIBFABRIC_NAME="libfabric-${LIBFABRIC_VERSION}"
   LIBFABRIC_URL="${LIBFABRIC_BASE_URL}/v${LIBFABRIC_VERSION}/${LIBFABRIC_NAME}.tar.bz2"
 
-  cd $cray_src_dir                       && \
-      wget ${LIBFABRIC_URL}              && \
-      tar -jxf ${LIBFABRIC_NAME}.tar.bz2    \
-          --no-same-owner                && \
-      cd ${LIBFABRIC_NAME}
+  cd $cray_src_dir
+  if [ -n "${OFFLINE_SOURCES:-}" ] && [ -f "${OFFLINE_SOURCES}/tar/${LIBFABRIC_NAME}.tar.bz2" ]; then
+      echo "cray-libs: using offline ${LIBFABRIC_NAME}.tar.bz2"
+      cp "${OFFLINE_SOURCES}/tar/${LIBFABRIC_NAME}.tar.bz2" .
+  else
+      wget ${LIBFABRIC_URL}
+  fi
+  tar -jxf ${LIBFABRIC_NAME}.tar.bz2 --no-same-owner
+  cd ${LIBFABRIC_NAME}
 fi
 
 ./autogen.sh                       && \

--- a/dockerfile_scripts/ompi.sh
+++ b/dockerfile_scripts/ompi.sh
@@ -36,10 +36,15 @@ OMPI_SRC_DIR=/tmp/openmpi-src
 OMPI_BASE_URL="https://download.open-mpi.org/release/open-mpi"
 OMPI_URL="${OMPI_BASE_URL}/${OMPI_VER}/openmpi-${OMPI_VER_NUM}.tar.gz"
 
-mkdir -p ${OMPI_SRC_DIR}                        && \
-  cd ${OMPI_SRC_DIR}                            && \
-  wget ${OMPI_URL}                              && \
-  tar -xzf openmpi-${OMPI_VER_NUM}.tar.gz       && \
+mkdir -p ${OMPI_SRC_DIR}
+cd ${OMPI_SRC_DIR}
+if [ -n "${OFFLINE_SOURCES:-}" ] && [ -f "${OFFLINE_SOURCES}/tar/openmpi-${OMPI_VER_NUM}.tar.gz" ]; then
+    echo "ompi: using offline openmpi-${OMPI_VER_NUM}.tar.gz"
+    cp "${OFFLINE_SOURCES}/tar/openmpi-${OMPI_VER_NUM}.tar.gz" .
+else
+    wget ${OMPI_URL}
+fi
+tar -xzf openmpi-${OMPI_VER_NUM}.tar.gz       && \
   cd openmpi-${OMPI_VER_NUM}                    && \
   ./configure ${OMPI_CONFIG_OPTIONS}            && \
   make                                          && \

--- a/dockerfile_scripts/scrape_libs.sh
+++ b/dockerfile_scripts/scrape_libs.sh
@@ -155,4 +155,32 @@ fi
 if [ "${1:-}" = "--" ]; then
     shift
 fi
-exec "${@}"
+
+# When the image was built with PRESERVE_BASE_ENTRYPOINT=1 the Makefile
+# snapshotted the base image's ENTRYPOINT and CMD into these files.
+# Replay them so the -hpc image behaves as a drop-in replacement for
+# the base: `podman run <hpc-image> <base's normal args>` just works.
+# Semantics match Docker's ENTRYPOINT+CMD merge rules:
+#   - user args present -> base entrypoint + user args (CMD is dropped)
+#   - no user args      -> base entrypoint + base CMD
+if [ "${HPC_PRESERVE_BASE_ENTRYPOINT:-0}" = "1" ] && \
+   [[ -s /container/etc/.base-entrypoint || -s /container/etc/.base-cmd ]]; then
+    base_ep=()
+    base_cmd=()
+    if [ -s /container/etc/.base-entrypoint ]; then
+        mapfile -t base_ep < /container/etc/.base-entrypoint
+    fi
+    if [ -s /container/etc/.base-cmd ]; then
+        mapfile -t base_cmd < /container/etc/.base-cmd
+    fi
+    if [ $# -eq 0 ]; then
+        set -- "${base_ep[@]}" "${base_cmd[@]}"
+    else
+        set -- "${base_ep[@]}" "$@"
+    fi
+fi
+
+# Guard exec against an arg starting with `-` (e.g. --model). exec's own
+# option parsing consumes anything looking like a flag before it hits
+# the command. Prefix `--` to end exec's option list.
+exec -- "${@}"

--- a/dockerfile_scripts/scrape_libs.sh
+++ b/dockerfile_scripts/scrape_libs.sh
@@ -165,13 +165,21 @@ fi
 #   - no user args      -> base entrypoint + base CMD
 if [ "${HPC_PRESERVE_BASE_ENTRYPOINT:-0}" = "1" ] && \
    [[ -s /container/etc/.base-entrypoint || -s /container/etc/.base-cmd ]]; then
+    # Read one arg per line, skipping blank lines defensively (docker
+    # inspect --format tends to append a trailing newline on top of the
+    # per-element {{println}}, which would otherwise produce a stray empty
+    # array element and pass '' as an arg to the base command).
     base_ep=()
     base_cmd=()
     if [ -s /container/etc/.base-entrypoint ]; then
-        mapfile -t base_ep < /container/etc/.base-entrypoint
+        while IFS= read -r _line || [ -n "$_line" ]; do
+            [ -n "$_line" ] && base_ep+=("$_line")
+        done < /container/etc/.base-entrypoint
     fi
     if [ -s /container/etc/.base-cmd ]; then
-        mapfile -t base_cmd < /container/etc/.base-cmd
+        while IFS= read -r _line || [ -n "$_line" ]; do
+            [ -n "$_line" ] && base_cmd+=("$_line")
+        done < /container/etc/.base-cmd
     fi
     if [ $# -eq 0 ]; then
         set -- "${base_ep[@]}" "${base_cmd[@]}"

--- a/dockerfile_scripts/scrape_libs.sh
+++ b/dockerfile_scripts/scrape_libs.sh
@@ -122,11 +122,11 @@ export OMPI_MCA_pml=${OMPI_MCA_pml:="^ucx"}
 if command -v nvidia-smi >/dev/null 2>&1; then
     # Have a cuda driver in the container so check against the host
     host_driver=`nvidia-smi --query-gpu=driver_version --format=csv | tail -n 1 | awk -F "." '{print $1}'`
-    if [ -n $CUDA_DRIVER_VERSION ] ; then
+    if [ -n "$CUDA_DRIVER_VERSION" ] ; then
 	container_driver=`echo $CUDA_DRIVER_VERSION | awk -F "." '{print $1}'`
-	if [ -n $host_driver ] ; then
-	    if [ -n $container_driver ] ; then
-		if [ $container_driver -gt $host_driver ] ; then
+	if [ -n "$host_driver" ] ; then
+	    if [ -n "$container_driver" ] ; then
+		if [ "$container_driver" -gt "$host_driver" ] ; then
 		    # Make sure the cuda forward compatible path is
 		    # prepended in case there is a driver mismatch between the
 		    # host and container

--- a/dockerfile_scripts/scrape_libs.sh
+++ b/dockerfile_scripts/scrape_libs.sh
@@ -148,5 +148,11 @@ if [ -r /container/hpc/lib/libnccl-net.so ]; then
     export LD_PRELOAD=/container/hpc/lib/libnccl-net.so:$LD_PRELOAD
 fi
 
-# Execute what we were told to execute
+# Execute what we were told to execute.
+# Strip a leading `--` argument-separator so bash's `exec` builtin
+# doesn't interpret it as an unknown option. Some base images (e.g.
+# vllm-openai) invoke their entrypoint with `-- ...`.
+if [ "${1:-}" = "--" ]; then
+    shift
+fi
 exec "${@}"

--- a/dockerfile_scripts/scrape_libs.sh
+++ b/dockerfile_scripts/scrape_libs.sh
@@ -164,22 +164,22 @@ fi
 #   - user args present -> base entrypoint + user args (CMD is dropped)
 #   - no user args      -> base entrypoint + base CMD
 if [ "${HPC_PRESERVE_BASE_ENTRYPOINT:-0}" = "1" ] && \
-   [[ -s /container/etc/.base-entrypoint || -s /container/etc/.base-cmd ]]; then
+   [[ -s /container/etc/base-capture/base-entrypoint || -s /container/etc/base-capture/base-cmd ]]; then
     # Read one arg per line, skipping blank lines defensively (docker
     # inspect --format tends to append a trailing newline on top of the
     # per-element {{println}}, which would otherwise produce a stray empty
     # array element and pass '' as an arg to the base command).
     base_ep=()
     base_cmd=()
-    if [ -s /container/etc/.base-entrypoint ]; then
+    if [ -s /container/etc/base-capture/base-entrypoint ]; then
         while IFS= read -r _line || [ -n "$_line" ]; do
             [ -n "$_line" ] && base_ep+=("$_line")
-        done < /container/etc/.base-entrypoint
+        done < /container/etc/base-capture/base-entrypoint
     fi
-    if [ -s /container/etc/.base-cmd ]; then
+    if [ -s /container/etc/base-capture/base-cmd ]; then
         while IFS= read -r _line || [ -n "$_line" ]; do
             [ -n "$_line" ] && base_cmd+=("$_line")
-        done < /container/etc/.base-cmd
+        done < /container/etc/base-capture/base-cmd
     fi
     if [ $# -eq 0 ]; then
         set -- "${base_ep[@]}" "${base_cmd[@]}"


### PR DESCRIPTION
Improved offline build in air gapped environments.
Created audit-offline-requirements script that scrapes URLs/tarballs/apt packages from the build scripts and Dockerfiles. Creates download script and Dockerfile that installs apt packages into the base container on the internet accessible staging system. Downloads URLs, tarballs and git repos into a offline-sources archive that the build scripts will use on the air gapped target.
Bug fixes for scrape_libs.sh.
Added to Makefile - optional PRESERVE_BASE_ENTRYPOINT - inspects the base container and  scrape_libs.sh replays ENTRYPOINT/CMD's.  This is opt-in.